### PR TITLE
feat: Support for precompiled builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,8 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
 
-      - name: Change to CLI directory
-        run: cd clients/cli
-
       - name: Build
+        working-directory: clients/cli
         run: cargo build --release
         env:
           RUSTFLAGS: "-C target-feature=+crt-static"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           target: ${{ matrix.target }}
 
       - name: Build
-        run: cargo build --release --features build_proto
+        run: cargo build --release
         env:
           RUSTFLAGS: "-C target-feature=+crt-static"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., v0.7.0)'
+        required: true
+        type: string
 
 jobs:
   build:
@@ -63,8 +69,9 @@ jobs:
             artifacts/nexus-network-linux
             artifacts/nexus-network-macos
             artifacts/nexus-network-windows.exe
-          draft: false
-          prerelease: false
+          draft: true
+          prerelease: true
           generate_release_notes: true
+          tag_name: ${{ github.event.inputs.version || github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build
         working-directory: clients/cli
-        run: cargo build --release
+        run: cargo build --release --features build_proto
         env:
           RUSTFLAGS: "-C target-feature=+crt-static"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
 
+      - name: Change to CLI directory
+        run: cd clients/cli
+
       - name: Build
         run: cargo build --release
         env:
@@ -48,7 +51,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
-          path: target/release/nexus-network${{ matrix.os == 'windows-latest' && '.exe' || '' }}
+          path: clients/cli/target/release/nexus-network${{ matrix.os == 'windows-latest' && '.exe' || '' }}
 
   release:
     name: Create Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    name: Build for ${{ matrix.os }}
+    name: Build for ${{ matrix.os }} (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -22,13 +22,19 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            artifact_name: nexus-network-linux
+            artifact_name: nexus-network-linux-x86_64
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            artifact_name: nexus-network-linux-arm64
           - os: macos-latest
             target: x86_64-apple-darwin
-            artifact_name: nexus-network-macos
+            artifact_name: nexus-network-macos-x86_64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact_name: nexus-network-macos-arm64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            artifact_name: nexus-network-windows.exe
+            artifact_name: nexus-network-windows-x86_64.exe
 
     steps:
       - uses: actions/checkout@v4
@@ -38,10 +44,18 @@ jobs:
         with:
           toolchain: stable
           target: ${{ matrix.target }}
+          override: true
+
+      - name: Verify toolchain
+        run: |
+          echo "Rust version: $(rustc --version)"
+          echo "Cargo version: $(cargo --version)"
+          echo "Target: $(rustc --print target)"
+          echo "Host: $(rustc --print host)"
 
       - name: Build
         working-directory: clients/cli
-        run: cargo build --release --features build_proto
+        run: cargo build --release
         env:
           RUSTFLAGS: "-C target-feature=+crt-static"
 
@@ -69,9 +83,11 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            artifacts/nexus-network-linux
-            artifacts/nexus-network-macos
-            artifacts/nexus-network-windows.exe
+            artifacts/nexus-network-linux-x86_64
+            artifacts/nexus-network-linux-arm64
+            artifacts/nexus-network-macos-x86_64
+            artifacts/nexus-network-macos-arm64
+            artifacts/nexus-network-windows-x86_64.exe
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact_name: nexus-network-linux
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            artifact_name: nexus-network-macos
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact_name: nexus-network-windows.exe
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release --features build_proto
+        env:
+          RUSTFLAGS: "-C target-feature=+crt-static"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: target/release/nexus-network${{ matrix.os == 'windows-latest' && '.exe' || '' }}
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            artifacts/nexus-network-linux
+            artifacts/nexus-network-macos
+            artifacts/nexus-network-windows.exe
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,11 @@ on:
       - 'v*'
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version to release (e.g., v0.7.0)'
+      create_release:
+        description: 'Create a GitHub release from the latest tag'
         required: true
-        type: string
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -52,6 +53,7 @@ jobs:
   release:
     name: Create Release
     needs: build
+    if: github.event.inputs.create_release == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -69,9 +71,8 @@ jobs:
             artifacts/nexus-network-linux
             artifacts/nexus-network-macos
             artifacts/nexus-network-windows.exe
-          draft: true
-          prerelease: true
+          draft: false
+          prerelease: false
           generate_release_notes: true
-          tag_name: ${{ github.event.inputs.version || github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest] # todo: ubuntu-latest, windows-latest
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,21 +20,21 @@ jobs:
       matrix:
         os: [macos-latest] # todo: ubuntu-latest, windows-latest
         include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            artifact_name: nexus-network-linux-x86_64
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            artifact_name: nexus-network-linux-arm64
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            artifact_name: nexus-network-macos-x86_64
+          #- os: ubuntu-latest
+          #  target: x86_64-unknown-linux-gnu
+          #  artifact_name: nexus-network-linux-x86_64
+          #- os: ubuntu-latest
+          #  target: aarch64-unknown-linux-gnu
+          #  artifact_name: nexus-network-linux-arm64
+          # - os: macos-latest
+          #  target: x86_64-apple-darwin
+          #  artifact_name: nexus-network-macos-x86_64
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact_name: nexus-network-macos-arm64
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            artifact_name: nexus-network-windows-x86_64.exe
+          # - os: windows-latest
+          #  target: x86_64-pc-windows-msvc
+          #   artifact_name: nexus-network-windows-x86_64.exe
 
     steps:
       - uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,52 @@
 # Contributing to the Nexus network
 
+> **Note:** This guide is for contributors who want to modify or improve the CLI itself. If you're just looking to use the CLI, please see the [main README](../README.md) for installation and usage instructions.
+
 The Nexus network is contributor-friendly. 
 We welcome all contributions, no matter your experience with Rust or cryptography.
 
 This document will help you get started. But first, **thank you for your interest in contributing!** We immensely appreciate quality contributions. This guide is intended to help you navigate the process.
 
 The [Discord][discord] is always available for any concerns you may have that are not covered in this guide, or for any other questions or discussions you want to raise with the Nexus team or broader Nexus community.
+
+## Development Setup
+
+### Prerequisites
+
+- Rust and Cargo (latest stable version)
+- Git
+- Protobuf compiler (if working with proto files)
+
+### Building from Source
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/nexus-xyz/network-api.git
+   cd network-api/clients/cli
+   ```
+
+2. Build the CLI:
+   ```bash
+   cargo build
+   ```
+
+3. Run tests:
+   ```bash
+   cargo test
+   ```
+
+4. Run the CLI:
+   ```bash
+   cargo run
+   ```
+
+### Proto Compilation
+
+By default, the build process skips proto compilation to make it easier for contributors to work on the codebase without needing protobuf tooling. If you need to modify or regenerate the proto files, you can enable proto compilation by using the `build_proto` feature:
+
+```bash
+cargo build --features build_proto
+```
 
 ### Code of Conduct
 
@@ -82,16 +123,6 @@ intend to continue the work before checking if they would mind if you took it ov
 remaining). When doing so, it is courteous to give the original contributor credit for the work they started, either by
 preserving their name and e-mail address in the commit log, or by using the `Author: ` or `Co-authored-by: ` metadata
 tag in the commits.
-
-#### Proto Compilation
-
-By default, the build process skips proto compilation to make it easier for contributors to work on the codebase without needing protobuf tooling. If you need to modify or regenerate the proto files, you can enable proto compilation by using the `build_proto` feature:
-
-```bash
-cargo build --features build_proto
-```
-
-<sub><sup>_Adapted from the [Reth contributing guide][reth-contributing]_.</sub></sup>
 
 [rust-coc]: https://github.com/rust-lang/rust/blob/master/CODE_OF_CONDUCT.md
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,29 @@ The [Discord][discord] is always available for any concerns you may have that ar
 
 ### Prerequisites
 
-- Rust and Cargo (latest stable version)
-- Git
-- Protobuf compiler (if working with proto files)
+- **Rust and Cargo**: Latest stable version
+  ```bash
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+  ```
+  Verify installation:
+  ```bash
+  rustc --version
+  cargo --version
+  ```
+
+- **Git**: For version control
+  ```bash
+  git --version
+  ```
+
+- **Protobuf Compiler**: Required if working with proto files
+  - macOS: `brew install protobuf`
+  - Ubuntu/Debian: `apt-get install protobuf-compiler`
+  - Windows: Download from [protobuf releases](https://github.com/protocolbuffers/protobuf/releases)
+  Verify installation:
+  ```bash
+  protoc --version
+  ```
 
 ### Building from Source
 
@@ -30,15 +50,31 @@ The [Discord][discord] is always available for any concerns you may have that ar
    cargo build
    ```
 
-3. Run tests:
-   ```bash
-   cargo test
-   ```
-
-4. Run the CLI:
+3. Run the CLI:
    ```bash
    cargo run
    ```
+
+### Code Quality Checks
+
+Before submitting changes, please run the following checks locally:
+
+```bash
+# Format code
+cargo fmt --check
+
+# Run clippy lints
+cargo clippy -- -D warnings
+
+# Check for unused dependencies
+cargo udeps
+
+# Check for security vulnerabilities
+cargo audit
+```
+
+These checks are the same ones that run in our CI pipeline. If they pass locally, your 
+changes are likely to pass CI as well.
 
 ### Proto Compilation
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-green.svg)](https://github.com/nexus-xyz/network-api/blob/main/LICENSE-APACHE)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/nexus-xyz/network-api/blob/main/LICENSE-MIT)
 [![Tests](https://github.com/nexus-xyz/network-api/actions/workflows/ci.yml/badge.svg)](https://github.com/nexus-xyz/network-api/actions/workflows/ci.yml)
-[![Crates.io](https://img.shields.io/crates/v/nexus-network)](https://crates.io/crates/nexus-network)
 
 # Nexus Network CLI
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-
 [![License](https://img.shields.io/badge/License-Apache_2.0-green.svg)](https://github.com/nexus-xyz/network-api/blob/main/LICENSE-APACHE)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/nexus-xyz/network-api/blob/main/LICENSE-MIT)
+[![Tests](https://github.com/nexus-xyz/network-api/actions/workflows/ci.yml/badge.svg)](https://github.com/nexus-xyz/network-api/actions/workflows/ci.yml)
+[![Crates.io](https://img.shields.io/crates/v/nexus-network)](https://crates.io/crates/nexus-network)
 
 # Nexus Network CLI
 
@@ -8,17 +9,22 @@ A high-performance command-line interface for contributing proofs to the Nexus n
 
 <figure>
     <a href="https://beta.nexus.xyz/">
-        <img src="assets/images/nexus-network-image.png" alt="Nexus Network visualization showing a distributed network of interconnected nodes with a 'Launch Network' button in the center">
+        <img src="assets/images/nexus-network-image.png" 
+             alt="Nexus Network visualization showing a distributed network of interconnected nodes with a 'Launch Network' button in the center">
     </a>
     <figcaption>
         <strong>Verifiable Computation on a Global Scale</strong><br>
-        We're building a global distributed prover network to unite the world's computers and power a new and better Internet: the Verifiable Internet. Connect to the beta and give it a try today.
+        We're building a global distributed prover network to unite the world's computers 
+        and power a new and better Internet: the Verifiable Internet. Connect to the beta 
+        and give it a try today.
     </figcaption>
 </figure>
 
 ## The Nexus Network
 
-The [Nexus Network](https://docs.nexus.xyz/network) is a global distributed prover network that unites the world's computers to power a new and better Internet: the Verifiable Internet.
+The [Nexus Network](https://docs.nexus.xyz/network) is a global distributed prover 
+network that unites the world's computers to power a new and better Internet: the 
+Verifiable Internet.
 
 There have been two testnets so far:
 - Testnet 0: [October 08 – 28, 2024](https://blog.nexus.xyz/nexus-launches-worlds-first-open-prover-network/)
@@ -29,115 +35,43 @@ There have been two testnets so far:
 
 ## Quick Start
 
-### Single-User Installation
+### Installation
 
-For the simplest one-command install (especially for local testing or personal use). This is what most users will want to do:
+#### Precompiled Binary (Recommended)
+
+For the simplest and most reliable installation:
 
 ```bash
 curl https://cli.nexus.xyz/ | sh
 ```
 
-**Note:** This script automatically installs Rust if you don’t have it and prompts for Terms of Use in an interactive shell.
+This will:
+1. Download and install the latest precompiled binary for your platform
+2. Prompt you to accept the Terms of Use
+3. Start the CLI in interactive mode
 
-Alternatively, if you’ve already downloaded `install.sh`:
+### Non-Interactive Installation
 
-```bash
-./install.sh
-```
-
-### CI
-
-The `install.sh` script is designed to do several things:
-
-
-1. Install Rust if it's not already installed... and do it non-interactively if possible, so it does not bother the user.
-2. Prompt the user to accept the Terms of Use (via bash) and enter their node id (via the Rust program)
-
-```sh
-# this is the part in the install.sh script has the brittle `< /dev/tty` part within CI environments
-(
-  cd "$REPO_PATH/clients/cli" || exit
-  cargo run --release -- start --env beta
-) < /dev/tty
-```
-
-
-
-This combination of bash and Rust is a bit brittle in CI environments. Consider these approaches instead:
-
-1. **Build from source**:
-   ```bash
-   git clone https://github.com/nexus-xyz/network-api
-   cd network-api/clients/cli
-   cargo build --release
-   ./target/release/nexus-network start --env beta
-   ```
-2. **Download the script locally** (and optionally set `NONINTERACTIVE=1` if you need it to run without prompts):
-   ```bash
-   curl -sSf https://cli.nexus.xyz/ -o install.sh
-   chmod +x install.sh
-   NONINTERACTIVE=1 ./install.sh
-   ```
-
-Building from source or running a downloaded script gives you more control over dependencies and versions, and avoids any unexpected prompts during automated runs.
-
----
-
-## Local Testing with a Local HTTP Server
-
-If you want to simulate `curl https://cli.nexus.xyz/ | sh` **locally**:
-
-1. In the project’s root directory, start a local server:
-   ```sh
-   python3 -m http.server 8080
-   ```
-2. In a separate terminal, run:
-   ```sh
-   curl -sSf http://localhost:8080/public/install.sh | sh -x
-   ```
-3. Observe the script output and verify installation logic.
-
-If you don’t have Rust installed, you will be prompted to install it (unless `NONINTERACTIVE=1` is set).
-
----
-
-## Prerequisites
-
-### Linux
+For automated installations (e.g., in CI):
 
 ```bash
-sudo apt update && sudo apt upgrade
-sudo apt install build-essential pkg-config libssl-dev git-all protobuf-compiler
+curl -sSf https://cli.nexus.xyz/ -o install.sh
+chmod +x install.sh
+NONINTERACTIVE=1 ./install.sh
 ```
-
-### macOS
-
-```bash
-brew install git
-```
-
-### Windows
-
-1. [Install WSL](https://learn.microsoft.com/en-us/windows/wsl/install).  
-2. Follow the Linux instructions above within WSL.
 
 ---
 
 ## Terms of Use
 
-Use of the CLI is subject to the [Terms of Use](https://nexus.xyz/terms-of-use). First-time users running interactively will be prompted to accept these terms. For **non-interactive acceptance** (e.g., in CI), run:
-
-```bash
-NONINTERACTIVE=1 sh install.sh
-```
-
-or set `NONINTERACTIVE=1` before invoking the script.
+Use of the CLI is subject to the [Terms of Use](https://nexus.xyz/terms-of-use). 
+First-time users running interactively will be prompted to accept these terms.
 
 ---
 
 ## Node ID
 
-During the CLI’s startup, you’ll be asked for your node ID. To skip prompts in a
+During the CLI's startup, you'll be asked for your node ID. To skip prompts in a
 non-interactive environment, manually create a `~/.nexus/config.json` in the
 following format:
 
@@ -151,9 +85,8 @@ following format:
 
 ## Current Limitations
 
-- Only the latest CLI version is supported.
-- No prebuilt binaries yet.
-- To submit programs to the network for proving, contact [growth@nexus.xyz](mailto:growth@nexus.xyz).
+- To submit programs to the network for proving, contact 
+  [growth@nexus.xyz](mailto:growth@nexus.xyz).
 
 ---
 
@@ -165,19 +98,16 @@ following format:
 
 ---
 
-## Repository Structure
-
-```txt
-network-api/
-├── assets/       # Media for documentation
-├── clients/
-│   └── cli/      # Main CLI implementation
-├── proto/        # Shared network interface definition
-└── public/       # Files hosted at cli.nexus.xyz
-```
-
----
-
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup and guidelines.
+Interested in contributing to the Nexus Network CLI? Check out our 
+[Contributor Guide](./CONTRIBUTING.md) for:
+
+- Development setup instructions
+- How to report issues and submit pull requests
+- Our code of conduct and community guidelines
+- Tips for working with the codebase
+
+For most users, we recommend using the precompiled binaries as described above. 
+The contributor guide is intended for those who want to modify or improve the CLI 
+itself.


### PR DESCRIPTION
When making a release, upload precompiled binaries to GitHub.

The install script should get those binaries instead of building.

Also updates documentation to separate usage instructions from building instructions.