### PR TITLE
chore: renaming network-api to nexus-cli

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to the Nexus network
+# Contributing to the Nexus CLI
 
-The Nexus network is contributor-friendly. 
+The Nexus CLI is contributor-friendly. 
 We welcome all contributions, no matter your experience with Rust or cryptography.
 
 This document will help you get started. But first, **thank you for your interest in contributing!** We immensely appreciate quality contributions. This guide is intended to help you navigate the process.
@@ -9,7 +9,7 @@ The [Discord][discord] is always available for any concerns you may have that ar
 
 ### Code of Conduct
 
-The Nexus network project adheres to the [Rust Code of Conduct][rust-coc]. This code of conduct describes the _minimum_ behavior
+The Nexus CLI project adheres to the [Rust Code of Conduct][rust-coc]. This code of conduct describes the _minimum_ behavior
 expected from all contributors.
 
 Instances of violations of the Code of Conduct can be reported by contacting the Nexus team.
@@ -55,7 +55,7 @@ If you have examples of other tools with the feature you are requesting, please 
 
 ## Resolving Issues
 
-Pull requests are the way concrete changes are made to the code, documentation, and dependencies of the Nexus network.
+Pull requests are the way concrete changes are made to the code, documentation, and dependencies of the Nexus CLI.
 
 Before making a large change, it is usually a good idea to first open an issue describing the change to solicit feedback and guidance. 
 This will increase the likelihood of the PR getting merged. Striking up a discussion on the [Discord][discord] to let the community know
@@ -72,7 +72,7 @@ request right away, others may have more detailed comments or feedback. This is 
 to evaluate whether the changes are correct and necessary.
 
 Remember to **always be aware of the person behind the code**. _How_ you communicate during reviews (of your code or others!) can have a significant impact on the success
-of the pull request. We never want the cost of a change that makes the Nexus network better to be a valued contributor not
+of the pull request. We never want the cost of a change that makes the Nexus CLI better to be a valued contributor not
 wanting to have anything to do with the project ever again. The goal is not just having good code. It's having a positive community that continues to turn good code into better code.
 
 #### Abandoned or stale pull requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ cargo build --features build_proto
 
 [rust-coc]: https://github.com/rust-lang/rust/blob/master/CODE_OF_CONDUCT.md
 
-[gh]: https://github.com/nexus-xyz/network-api
+[gh]: https://github.com/nexus-xyz/nexus-cli
 
 [discord]: https://discord.com/invite/nexus-xyz
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ A high-performance command-line interface for contributing proofs to the Nexus n
     </figcaption>
 </figure>
 
-## The Nexus Network
+## Nexus Network
 
-The [Nexus Network](https://docs.nexus.xyz/network) is a global distributed prover network that unites the world's computers to power a new and better Internet: the Verifiable Internet.
+[Nexus](https://nexus.xyz/) is a global distributed prover network that unites the world's computers to power a new and better Internet: the Verifiable Internet.
 
 There have been several testnets so far:
 - Testnet 0: [October 08 – 28, 2024](https://blog.nexus.xyz/nexus-launches-worlds-first-open-prover-network/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Release](https://img.shields.io/github/v/release/nexus-xyz/network-api.svg)](https://github.com/nexus-xyz/network-api/releases)
-[![License](https://img.shields.io/badge/License-Apache_2.0-green.svg)](https://github.com/nexus-xyz/network-api/blob/main/LICENSE-APACHE)
-[![License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/nexus-xyz/network-api/blob/main/LICENSE-MIT)
+[![Release](https://img.shields.io/github/v/release/nexus-xyz/nexus-cli.svg)](https://github.com/nexus-xyz/nexus-cli/releases)
+[![License](https://img.shields.io/badge/License-Apache_2.0-green.svg)](https://github.com/nexus-xyz/nexus-cli/blob/main/LICENSE-APACHE)
+[![License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/nexus-xyz/nexus-cli/blob/main/LICENSE-MIT)
 
 # Nexus Network CLI
 
@@ -67,8 +67,8 @@ This combination of bash and Rust is a bit brittle in CI environments. Consider 
 
 1. **Build from source**:
    ```bash
-   git clone https://github.com/nexus-xyz/network-api
-   cd network-api/clients/cli
+   git clone https://github.com/nexus-xyz/nexus-cli
+   cd nexus-cli/clients/cli
    cargo build --release
    ./target/release/nexus-network start --env beta
    ```
@@ -107,7 +107,7 @@ If you don’t have Rust installed, you will be prompted to install it (unless `
 
 ```bash
 sudo apt update && sudo apt upgrade
-sudo apt install build-essential pkg-config libssl-dev git-all protobuf-compiler
+sudo apt install build-essential pkg-config libssl-dev git-all
 ```
 
 ### macOS
@@ -131,7 +131,7 @@ Use of the CLI is subject to the [Terms of Use](https://nexus.xyz/terms-of-use).
 NONINTERACTIVE=1 sh install.sh
 ```
 
-or set `NONINTERACTIVE=1` before invoking the script.
+or `export NONINTERACTIVE=1` before invoking the curl installer.
 
 ---
 
@@ -161,14 +161,14 @@ following format:
 
 - [Network FAQ](https://docs.nexus.xyz/layer-1/network-devnet/faq)  
 - [Discord Community](https://discord.gg/nexus-xyz)  
-- Technical issues? [Open an issue](https://github.com/nexus-xyz/network-api/issues)
+- Technical issues? [Open an issue](https://github.com/nexus-xyz/nexus-cli/issues)
 
 ---
 
 ## Repository Structure
 
 ```txt
-network-api/
+nexus-cli/
 ├── assets/       # Media for documentation
 ├── clients/
 │   └── cli/      # Main CLI implementation

--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "nexus-network"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "chrono",
  "clap",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-network"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.75"
 build = "build.rs"

--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -55,7 +55,7 @@ To request an API key, contact us at growth@nexus.xyz.
 
 ## Modifying source
 
-The curl command in the quick start section downloads this repo to $HOME/.nexus/network-api
+The curl command in the quick start section downloads this repo to $HOME/.nexus/nexus-cli
 and automatically runs it. If you want to modify the CLI, it's better to clone the GitHub
 repo somewhere else.
 

--- a/clients/cli/src/utils/updater.rs
+++ b/clients/cli/src/utils/updater.rs
@@ -23,8 +23,8 @@ pub const RESET: &str = "\x1b[0m"; // Reset color
 
 // The file to store the current version in
 pub const VERSION_FILE: &str = ".current_version";
-pub const REMOTE_REPO: &str = "https://github.com/nexus-xyz/network-api";
-pub const FALLBACK_VERSION: Version = Version::new(0, 3, 6); // 0.3.6
+pub const REMOTE_REPO: &str = "https://github.com/nexus-xyz/nexus-cli";
+pub const FALLBACK_VERSION: Version = Version::new(0, 7, 1); // 0.7.1
 
 #[derive(Debug, Clone, Copy, PartialEq, clap::ValueEnum)]
 pub enum AutoUpdaterMode {
@@ -48,10 +48,10 @@ impl UpdaterConfig {
             AutoUpdaterMode::Production => Self {
                 mode,
                 repo_path: format!(
-                    "{}/.nexus/network-api",
+                    "{}/.nexus/nexus-cli",
                     std::env::var("HOME").unwrap_or_default()
                 ),
-                remote_repo: String::from("https://github.com/nexus-xyz/network-api.git"),
+                remote_repo: String::from("https://github.com/nexus-xyz/nexus-cli.git"),
                 update_interval: 3600, // check for updates every 1 hour (3600 seconds)
                 hostname,
             },

--- a/public/install.sh
+++ b/public/install.sh
@@ -67,7 +67,7 @@ fi
 # -----------------------------------------------------------------------------
 # 6) Clone or update the network-api repository in $NEXUS_HOME.
 # -----------------------------------------------------------------------------
-REPO_PATH="$NEXUS_HOME/network-api"
+REPO_PATH="$NEXUS_HOME/nexus-cli"
 if [ -d "$REPO_PATH" ]; then
   echo "$REPO_PATH exists. Updating."
   (
@@ -79,7 +79,7 @@ if [ -d "$REPO_PATH" ]; then
 else
   (
     cd "$NEXUS_HOME" || exit
-    git clone https://github.com/nexus-xyz/network-api
+    git clone https://github.com/nexus-xyz/nexus-cli
   )
 fi
 

--- a/public/install.sh
+++ b/public/install.sh
@@ -65,7 +65,7 @@ if [ "$GIT_IS_AVAILABLE" != 0 ]; then
 fi
 
 # -----------------------------------------------------------------------------
-# 6) Clone or update the network-api repository in $NEXUS_HOME.
+# 6) Clone or update the nexus-cli repository in $NEXUS_HOME.
 # -----------------------------------------------------------------------------
 REPO_PATH="$NEXUS_HOME/nexus-cli"
 if [ -d "$REPO_PATH" ]; then


### PR DESCRIPTION
- docs: Repo name changed to focus more on CLI
- chore: Update installer to use new repo name