### PR TITLE
docs: clarified phrasing in "Current Limitations" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ following format:
 ## Current Limitations
 
 - Only the latest CLI version is supported.
-- No prebuilt binaries yet.
+- Prebuilt binaries are not yet available.
 - To submit programs to the network for proving, contact [growth@nexus.xyz](mailto:growth@nexus.xyz).
 
 ---


### PR DESCRIPTION
noticed the line "No prebuilt binaries yet." felt a bit abrupt, so I reworded it to "Prebuilt binaries are not yet available." - reads a bit smoother and keeps the meaning intact.