### PR TITLE
chore: Use localhost:50505 for local proving

### DIFF
--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -10,7 +10,7 @@ pub enum Environment {
 impl Environment {
     pub fn orchestrator_url(&self) -> String {
         match self {
-            Environment::Local => "http://localhost:8080".to_string(),
+            Environment::Local => "http://localhost:50505".to_string(),
             Environment::Dev => "https://dev.orchestrator.nexus.xyz".to_string(),
             Environment::Staging => "https://staging.orchestrator.nexus.xyz".to_string(),
             Environment::Beta => "https://beta.orchestrator.nexus.xyz".to_string(),


### PR DESCRIPTION
This is the default port exposed by the orchestrator.