### PR TITLE
chore(ci): upgrade action-gh-release to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             artifacts/nexus-network-linux


### PR DESCRIPTION
Replaced deprecated `softprops/action-gh-release@v1` with `softprops/action-gh-release@v2`
(latest stable v2.2.2) to receive ongoing fixes and features.

[Referance](https://github.com/softprops/action-gh-release/releases/tag/v2.2.2)