### PR TITLE
chore: Replace `num_cpus` with `available_parallelism`

### DIFF
--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -1242,7 +1242,6 @@ dependencies = [
  "log",
  "md5",
  "nexus-sdk",
- "num_cpus",
  "postcard",
  "prost 0.13.1",
  "prost-build 0.13.1",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -54,7 +54,6 @@ serde_json = { version = "1.0.138" }
 sysinfo = "0.33.1"
 nexus-sdk = { git = "https://github.com/nexus-xyz/nexus-zkvm", tag = "0.3.1" }
 rayon = "1.10"
-num_cpus = "1.16"
 sha3 = "0.10.8"
 log = "0.4.26"
 postcard = "1.1.1"

--- a/clients/cli/src/flops.rs
+++ b/clients/cli/src/flops.rs
@@ -1,13 +1,14 @@
 use rayon::prelude::*;
 use std::hint::black_box;
 use std::time::Instant;
+use std::thread::available_parallelism;
 
 const NTESTS: u64 = 1_000_000;
 const OPERATIONS_PER_ITERATION: u64 = 4; // sin, add, multiply, divide
 const NUM_REPEATS: usize = 5; // Number of repeats to average the results
 
-pub fn measure_flops() -> f32 {
-    let num_cores = num_cpus::get() as u64;
+pub fn measure_flops() -> Result<f32, Box<dyn std::error::Error>> {
+    let num_cores: u64 = available_parallelism()?.get().try_into()?;
     println!("Using {} logical cores for FLOPS measurement", num_cores);
 
     let avg_flops: f64 = (0..NUM_REPEATS)
@@ -30,5 +31,5 @@ pub fn measure_flops() -> f32 {
         .sum::<f64>()
         / NUM_REPEATS as f64; // Average the FLOPS over all repeats
 
-    (avg_flops / 1e9) as f32 // Convert to GFLOP/s and cast to f32
+    Ok((avg_flops / 1e9) as f32) // Convert to GFLOP/s and cast to f32
 }

--- a/clients/cli/src/orchestrator_client.rs
+++ b/clients/cli/src/orchestrator_client.rs
@@ -126,7 +126,7 @@ impl OrchestratorClient {
         proof: Vec<u8>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (program_memory, total_memory) = get_memory_info();
-        let flops = measure_flops();
+        let flops = measure_flops()?;
 
         let request = SubmitProofRequest {
             task_id: task_id.to_string(),

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -224,7 +224,7 @@ pub async fn start_prover(
                     .underline()
                     .bright_cyan()
             );
-            let flops = flops::measure_flops();
+            let flops = flops::measure_flops()?;
             let flops_formatted = format!("{:.2}", flops);
             let flops_str = format!("{} FLOPS", flops_formatted);
             println!(


### PR DESCRIPTION
The end result is the same and `available_parallelism` is available since version `1.59`. 