### PR TITLE
fix: Use existing config by default when `NONINTERACTIVE=1` is set

### DIFF
--- a/clients/cli/src/setup.rs
+++ b/clients/cli/src/setup.rs
@@ -100,6 +100,10 @@ pub async fn run_initial_setup() -> SetupResult {
             node_id
         );
 
+        if std::env::var_os("NONINTERACTIVE").is_some() {
+            return SetupResult::Connected(node_id);
+        }
+
         //ask the user if they want to use the existing config
         println!("Do you want to use the existing user account? [Y/n]");
         let mut use_existing_config = String::new();


### PR DESCRIPTION
Don't ask the user if they want to use the existing config when `NONINTERACTIVE=1` is set