### PR TITLE
feat(cli): Add ASCII Nexus Cube logo to CLI startup banner

### DIFF
--- a/clients/cli/src/utils/cli_branding.rs
+++ b/clients/cli/src/utils/cli_branding.rs
@@ -10,6 +10,18 @@ pub const LOGO_NAME: &str = r#"
 "#;
 
 pub fn print_banner() {
+    // Add ASCII cube logo first
+    let cube_logo = r#"
+     _______
+    /      /\
+   /______/  \
+   \      \  /
+    \______\/
+   "#;
+
+    for line in cube_logo.lines() {
+        println!("{}", line.bright_blue());
+    }
     // Split the logo into lines and color them differently
     let logo_lines: Vec<&str> = LOGO_NAME.lines().collect();
     for line in logo_lines {


### PR DESCRIPTION
- Improves CLI branding & visual identity.
- Helps users immediately associate CLI startup with Nexus.
- Simple visual enhancement with no functional impact.


Closes #1479