### PR TITLE
ci: Adds job to build and push Docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: clients/cli
+          file: clients/cli/Dockerfile  # Optional, but explicitly specify the Dockerfile path
           push: true
           tags: nexusxyz/nexus-network:latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
@@ -38,7 +38,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/nexus-network:latest
+          tags: nexusxyz/nexus-network:latest
 
   build-linux-x86_64:
     name: Build Linux (x86_64)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,34 @@ on:
         type: boolean
         default: false
 
+env:
+    # Set the default Rust toolchain to use for all jobs
+    RUSTUP_TOOLCHAIN: nightly-2025-04-06
+
 jobs:
+  build-docker:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/nexus-network:latest
+
   build-linux-x86_64:
     name: Build Linux (x86_64)
     runs-on: ubuntu-latest
@@ -25,7 +52,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-04-06
+          toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
           targets: x86_64-unknown-linux-gnu
           components: rustfmt
 
@@ -66,7 +93,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-04-06
+          toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
           targets: aarch64-unknown-linux-gnu
           components: rustfmt
 
@@ -74,7 +101,7 @@ jobs:
       - name: Ensure targets are installed (fallback)
         run: |
           rustup target add aarch64-unknown-linux-gnu
-          rustup component add rust-src --toolchain nightly-2025-04-06
+          rustup component add rust-src --toolchain ${{ env.RUSTUP_TOOLCHAIN }}
 
       - name: Install ARM64 Linux linker
         run: |
@@ -120,7 +147,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-04-06
+          toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
           targets: x86_64-apple-darwin
           components: rustfmt, rust-src
 
@@ -128,7 +155,7 @@ jobs:
       - name: Ensure targets are installed (fallback)
         run: |
           rustup target add x86_64-apple-darwin
-          rustup component add rust-src --toolchain nightly-2025-04-06
+          rustup component add rust-src --toolchain  ${{ env.RUSTUP_TOOLCHAIN }}
 
       - name: Debug Rust environment
         run: |
@@ -143,7 +170,7 @@ jobs:
         working-directory: clients/cli
         run: cargo +nightly-2025-04-06 build --release --target=x86_64-apple-darwin -Z build-std=std,panic_abort
         env:
-          RUSTUP_TOOLCHAIN: nightly-2025-04-06
+          RUSTUP_TOOLCHAIN:  ${{ env.RUSTUP_TOOLCHAIN }}
           RUSTC_BOOTSTRAP: 1
 
       # Rename the binary to indicate the target OS
@@ -173,7 +200,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-04-06
+          toolchain:  ${{ env.RUSTUP_TOOLCHAIN }}
           targets: aarch64-apple-darwin
           components: rustfmt, rust-src
 
@@ -216,7 +243,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-04-06
+          toolchain:  ${{ env.RUSTUP_TOOLCHAIN }}
           targets: x86_64-pc-windows-msvc
           components: rustfmt, rust-src
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,8 @@ jobs:
           tags: |
             nexusxyz/nexus-cli:latest
             nexusxyz/nexus-cli:${{ github.sha }}
+            nexusxyz/nexus-cli:${{ github.ref_name }}
+
 
   build-linux-x86_64:
     name: Build Linux (x86_64)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,12 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: clients/cli
-          file: clients/cli/Dockerfile  # Optional, but explicitly specify the Dockerfile path
+          file: clients/cli/Dockerfile  # Optional. Explicitly specify the Dockerfile path
           push: true
-          tags: nexusxyz/nexus-network:latest
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            nexusxyz/nexus-cli:latest
+            nexusxyz/nexus-cli:${{ github.sha }}
 
   build-linux-x86_64:
     name: Build Linux (x86_64)

--- a/clients/cli/.dockerignore
+++ b/clients/cli/.dockerignore
@@ -1,0 +1,4 @@
+target/
+.git/
+docs/
+tests/

--- a/clients/cli/Dockerfile
+++ b/clients/cli/Dockerfile
@@ -14,13 +14,13 @@ WORKDIR /app
 
 # Cache dependencies
 COPY Cargo.toml Cargo.lock ./
-RUN cargo fetch
+RUN cargo fetch --locked
 
 # Copy source code
 COPY . .
 
 # Build the actual app
-RUN cargo build --release
+RUN cargo build --release --locked
 
 ####################################################################################################
 ## Final image

--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -84,7 +84,7 @@ If you encounter an error about `protoc` not being installed, you can install it
 
 ```bash
 docker pull nexusxyz/network-cli:latest
-docker run -it --init nexusxyz/network-cli:latest start
+docker run -it --init nexusxyz/nexus-cli:latest start --env beta
 ```
 
 #### macOS

--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -83,7 +83,7 @@ If you encounter an error about `protoc` not being installed, you can install it
 #### Docker
 
 ```bash
-docker pull nexusxyz/network-cli:latest
+docker pull nexusxyz/nexus-cli:latest
 docker run -it --init nexusxyz/nexus-cli:latest start --env beta
 ```
 


### PR DESCRIPTION
Adds a job to the Github release workflow to build and push the CLI's Docker image to Docker Hub.

- Multi-architecture Build for amd64 and arm64. (This is pretty slow...)
- Tags with latest, github SHA, and git tag

Fixes: https://linear.app/nexus-labs/issue/NET-1193/cli-release-workflow-for-docker-image