### PR TITLE
ci: Adds version to release binary names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - "v*"            # Trigger on tag push (e.g. "v1.0.0"). Adjust pattern as needed.
-  workflow_dispatch:    # Allow manual triggering of the workflow.
+  workflow_dispatch: # Allow manual triggering of the workflow.
     inputs:
       create_release:
         description: 'Create a GitHub release from the latest tag'
@@ -13,8 +13,10 @@ on:
         default: false
 
 env:
-    # Set the default Rust toolchain to use for all jobs
-    RUSTUP_TOOLCHAIN: nightly-2025-04-06
+  # Set the default Rust toolchain to use for all jobs
+  RUSTUP_TOOLCHAIN: nightly-2025-04-06
+  # The version is the tag name if this is a tag push, otherwise 'dev'
+  VERSION: ${{ github.ref_type == 'tag' && github.ref_name || 'dev' }}
 
 jobs:
   build-docker:
@@ -43,7 +45,7 @@ jobs:
           tags: |
             nexusxyz/nexus-cli:latest
             nexusxyz/nexus-cli:${{ github.sha }}
-            nexusxyz/nexus-cli:${{ github.ref_name }}
+            nexusxyz/nexus-cli:${{ env.VERSION }}
 
 
   build-linux-x86_64:
@@ -74,17 +76,17 @@ jobs:
         working-directory: clients/cli
         run: cargo build --release --target x86_64-unknown-linux-gnu
 
-      # Rename the binary to indicate the target OS
+      # Rename the binary to indicate the target OS and version
       - name: Rename binary
         working-directory: clients/cli/target/x86_64-unknown-linux-gnu/release/
-        run: cp nexus-network nexus-network-linux-x86_64
+        run: cp nexus-network nexus-network-linux-x86_64-${{ env.VERSION }}
 
       # Upload the binary as an artifact
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: nexus-network-linux-x86_64 # Name of the artifact
-          path: clients/cli/target/x86_64-unknown-linux-gnu/release/nexus-network-linux-x86_64 # Path to file to upload
+          name: nexus-network-linux-x86_64-${{ env.VERSION }} # Name of the artifact
+          path: clients/cli/target/x86_64-unknown-linux-gnu/release/nexus-network-linux-x86_64-${{ env.VERSION }} # Path to file to upload
 
 
   build-linux-arm64:
@@ -128,17 +130,17 @@ jobs:
           export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
           cargo build -Zbuild-std=std,panic_abort --release --target aarch64-unknown-linux-gnu
 
-      # Rename the binary to indicate the target OS
+      # Rename the binary to indicate the target OS and version
       - name: Rename binary
         working-directory: clients/cli/target/aarch64-unknown-linux-gnu/release/
-        run: cp nexus-network nexus-network-linux-arm64
+        run: cp nexus-network nexus-network-linux-arm64-${{ env.VERSION }}
 
       # Upload the binary as an artifact
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: nexus-network-linux-arm64 # Name of the artifact
-          path: clients/cli/target/aarch64-unknown-linux-gnu/release/nexus-network-linux-arm64 # Path to file to upload
+          name: nexus-network-linux-arm64-${{ env.VERSION }} # Name of the artifact
+          path: clients/cli/target/aarch64-unknown-linux-gnu/release/nexus-network-linux-arm64-${{ env.VERSION }} # Path to file to upload
 
   build-macos-x86_64:
     name: Build macOS (x86_64)
@@ -176,27 +178,27 @@ jobs:
         working-directory: clients/cli
         run: cargo +nightly-2025-04-06 build --release --target=x86_64-apple-darwin -Z build-std=std,panic_abort
         env:
-          RUSTUP_TOOLCHAIN:  ${{ env.RUSTUP_TOOLCHAIN }}
+          RUSTUP_TOOLCHAIN: ${{ env.RUSTUP_TOOLCHAIN }}
           RUSTC_BOOTSTRAP: 1
 
-      # Rename the binary to indicate the target OS
+      # Rename the binary to indicate the target OS and version
       - name: Rename binary
         working-directory: clients/cli/target/x86_64-apple-darwin/release/
-        run: cp nexus-network nexus-network-macos-x86_64
+        run: cp nexus-network nexus-network-macos-x86_64-${{ env.VERSION }}
 
 
       # Upload the binary as an artifact
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: nexus-network-macos-x86_64 # Name of the artifact
-          path: clients/cli/target/x86_64-apple-darwin/release/nexus-network-macos-x86_64 # Path to file to upload
+          name: nexus-network-macos-x86_64-${{ env.VERSION }} # Name of the artifact
+          path: clients/cli/target/x86_64-apple-darwin/release/nexus-network-macos-x86_64-${{ env.VERSION }} # Path to file to upload
 
 
   build-macos-arm64:
     name: Build macOS (ARM64)
     runs-on: macos-latest
-#    needs: build-linux   # Ensure Linux job (and release creation) runs first
+    #    needs: build-linux   # Ensure Linux job (and release creation) runs first
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -206,7 +208,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain:  ${{ env.RUSTUP_TOOLCHAIN }}
+          toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
           targets: aarch64-apple-darwin
           components: rustfmt, rust-src
 
@@ -223,17 +225,17 @@ jobs:
         working-directory: clients/cli
         run: cargo build --release --target=aarch64-apple-darwin
 
-      # Rename the binary to indicate the target OS and platform
+      # Rename the binary to indicate the target OS and platform and version
       - name: Rename binary
         working-directory: clients/cli/target/aarch64-apple-darwin/release/
-        run: cp nexus-network nexus-network-macos-arm64
+        run: cp nexus-network nexus-network-macos-arm64-${{ env.VERSION }}
 
       # Upload the binary as an artifact
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: nexus-network-macos-arm64 # Name of the artifact
-          path: clients/cli/target/aarch64-apple-darwin/release/nexus-network-macos-arm64 # Path to file to upload
+          name: nexus-network-macos-arm64-${{ env.VERSION }} # Name of the artifact
+          path: clients/cli/target/aarch64-apple-darwin/release/nexus-network-macos-arm64-${{ env.VERSION }} # Path to file to upload
 
 
   build-windows-x86_64:
@@ -249,7 +251,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain:  ${{ env.RUSTUP_TOOLCHAIN }}
+          toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
           targets: x86_64-pc-windows-msvc
           components: rustfmt, rust-src
 
@@ -266,7 +268,7 @@ jobs:
         working-directory: clients/cli
         run: cargo build --release --target=x86_64-pc-windows-msvc
 
-      # Rename the binary to indicate the target OS and platform
+      # Rename the binary to indicate the target OS, platform, and version
       - name: Rename binary
         working-directory: clients/cli/target/x86_64-pc-windows-msvc/release/
         run: cp nexus-network.exe nexus-network-windows-x86_64.exe
@@ -281,7 +283,7 @@ jobs:
   release:
     # Create a GitHub release with the built binaries
     name: Create Release
-    needs: [build-linux-x86_64, build-linux-arm64, build-macos-x86_64, build-macos-arm64, build-windows-x86_64]
+    needs: [ build-linux-x86_64, build-linux-arm64, build-macos-x86_64, build-macos-arm64, build-windows-x86_64 ]
     if: github.event.inputs.create_release == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
@@ -304,13 +306,17 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            artifacts/nexus-network-macos-arm64
-            artifacts/nexus-network-macos-x86_64
-            artifacts/nexus-network-linux-arm64
-            artifacts/nexus-network-linux-x86_64
-            artifacts/nexus-network-windows-x86_64.exe
+            artifacts/nexus-network-macos-arm64-${{ env.VERSION }}
+            artifacts/nexus-network-macos-x86_64-${{ env.VERSION }}
+            artifacts/nexus-network-linux-arm64-${{ env.VERSION }}
+            artifacts/nexus-network-linux-x86_64-${{ env.VERSION }}
+            artifacts/nexus-network-windows-x86_64-${{ env.VERSION }}.exe
           draft: false
           prerelease: false
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+
+


### PR DESCRIPTION
Adds version to release binaries

TODO: Confirm that this is compatible with the install script at https://cli.nexus.xyz

Fixes: https://linear.app/nexus-labs/issue/NET-1172/cli-add-version-to-release-binary-file-names