### PR TITLE
fix: exclude SHA256 files from latest release URL retrieval

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -128,6 +128,7 @@ esac
 # Get the latest release URL
 LATEST_RELEASE_URL=$(curl -s https://api.github.com/repos/nexus-xyz/nexus-cli/releases/latest |
     grep "browser_download_url.*$BINARY_NAME" |
+    grep -v ".sha256" |
     cut -d '"' -f 4)
 
 if [ -z "$LATEST_RELEASE_URL" ]; then


### PR DESCRIPTION
When LATEST_RELEASE_URL is fetched, links with the .sha256 extension are also being included. This prevents the curl request from being made, and because the folder isn't created, node cannot be run.

Fixes: #1539