### PR TITLE
ci: Add workflow_dispatch to Firebase hosting release workflow

### DIFF
--- a/.github/workflows/firebase-hosting-release.yml
+++ b/.github/workflows/firebase-hosting-release.yml
@@ -4,7 +4,8 @@
 name: Deploy to Firebase Hosting on release
 on:
   release:
-    types: [published]
+    types: [ published ]
+  workflow_dispatch:  # Manual trigger
 
 jobs:
   build_and_deploy:


### PR DESCRIPTION
The firebase-hosting-release workflow is triggered by manual releases, but is not triggered when a release is created by the  release.yml workflow (e.g., when a tag is pushed). This allows the firebase-hosting-release.yml workflow to be manually triggered
