### PR TITLE
docs: Adds --node-id to README and installation script instruction

### DIFF
--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -7,10 +7,11 @@ It is the **highest-performance** way to participate.
 
 ## 🪄 Quick Start
 
-Install and run the CLI via the install script:
+Run the installation script and start the CLI with your node ID:
 
 ```bash
 curl https://cli.nexus.xyz/ | sh
+nexus start --node-id <your-node-id>
 ```
 
 Or, with Docker:

--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -11,7 +11,13 @@ Run the installation script and start the CLI with your node ID:
 
 ```bash
 curl https://cli.nexus.xyz/ | sh
-nexus start --node-id <your-node-id>
+nexus-network start --node-id <your-node-id>
+```
+
+For troubleshooting or to see available command line options, run:
+
+```bash
+nexus-network --help start
 ```
 
 Or, with Docker:

--- a/public/install.sh
+++ b/public/install.sh
@@ -174,6 +174,6 @@ fi
 
 echo ""
 echo "${GREEN}Installation complete!${NC}"
-echo "To use the Nexus CLI, restart your terminal or run:"
+echo "Restart your terminal or run the following command to update your PATH:"
 echo "  source $PROFILE_FILE"
-echo "You can now run the Nexus CLI with: nexus-network start --env beta"
+echo "Start the Nexus CLI with: nexus-network start --node-id <your-node-id>"


### PR DESCRIPTION
Highlight that the node ID must currently be set as a command-line argument