### PR TITLE
Extracts Orchestrator trait to allow mocking in unit tests

### DIFF
--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -196,6 +196,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +1552,7 @@ name = "nexus-network"
 version = "0.8.1"
 dependencies = [
  "assert_cmd",
+ "async-trait",
  "chrono",
  "clap",
  "colored",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -47,6 +47,7 @@ sysinfo = "0.33.1"
 thiserror = "2.0.12"
 tokio = { version = "1.38", features = ["full"] }
 uuid = "1.16.0"
+async-trait = "0.1.88"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -13,7 +13,7 @@ mod ui;
 
 use crate::config::{get_config_path, Config};
 use crate::environment::Environment;
-use crate::orchestrator_client::OrchestratorClient;
+use crate::orchestrator_client::{Orchestrator, OrchestratorClient};
 use clap::{Parser, Subcommand};
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -1,7 +1,7 @@
 use nexus_sdk::{stwo::seq::Stwo, Local, Prover, Viewable};
 use std::time::Duration;
 
-use crate::orchestrator_client::OrchestratorClient;
+use crate::orchestrator_client::{Orchestrator, OrchestratorClient};
 use crate::{analytics, environment::Environment};
 use colored::Colorize;
 use log::{error, info, warn};


### PR DESCRIPTION
Extracts an "Orchestrator" trait from the OrchestratorClient. This is preparation for additional unit tests.

Fixes: https://linear.app/nexus-labs/issue/NET-1304/cli-mockable-interface-for-orchestratorclient