### PR TITLE
fix: Updates GetProofTaskRequest proto message to include public key

### DIFF
--- a/clients/cli/src/orchestrator/client.rs
+++ b/clients/cli/src/orchestrator/client.rs
@@ -106,34 +106,47 @@ impl Orchestrator for OrchestratorClient {
 
     /// Registers a new node with the orchestrator.
     async fn register_node(&self, user_id: &str) -> Result<String, OrchestratorError> {
+        let url = format!("{}/v3/nodes", self.environment.orchestrator_url());
         let request = RegisterNodeRequest {
             node_type: NodeType::CliProver as i32,
             user_id: user_id.to_string(),
         };
+        let request_bytes = request.encode_to_vec();
+        let response = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/octet-stream")
+            .body(request_bytes)
+            .send()
+            .await?;
 
-        match self
-            .make_request::<RegisterNodeRequest, RegisterNodeResponse>(
-                "/nodes",
-                Method::POST,
-                &request,
-            )
-            .await?
-        {
-            Some(response) => Ok(response.node_id),
-            None => Err(OrchestratorError::ResponseError(
-                "No node ID received".to_string(),
-            )),
+        if !response.status().is_success() {
+            return Err(OrchestratorError::HTTPError {
+                status: response.status().as_u16(),
+                message: response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "Failed to read response text".to_string()),
+            });
         }
+
+        let response_bytes = response.bytes().await?;
+        let register_node_response: RegisterNodeResponse =
+            match RegisterNodeResponse::decode(response_bytes) {
+                Ok(msg) => msg,
+                Err(_e) => return Err(OrchestratorError::DecodeError(_e)),
+            };
+        Ok(register_node_response.node_id)
     }
 
     async fn get_tasks(&self, node_id: &str) -> Result<Vec<Task>, OrchestratorError> {
+        let url = format!("{}/v3/tasks", self.environment.orchestrator_url());
         let request = GetTasksRequest {
             node_id: node_id.to_string(),
             next_cursor: "".to_string(),
         };
         let request_bytes = request.encode_to_vec();
 
-        let url = format!("{}/v3/tasks", self.environment.orchestrator_url());
         let response = self
             .client
             .get(&url)
@@ -164,25 +177,46 @@ impl Orchestrator for OrchestratorClient {
         Ok(tasks)
     }
 
-    async fn get_proof_task(&self, node_id: &str) -> Result<Task, OrchestratorError> {
+    async fn get_proof_task(
+        &self,
+        node_id: &str,
+        verifying_key: VerifyingKey,
+    ) -> Result<Task, OrchestratorError> {
         let request = GetProofTaskRequest {
             node_id: node_id.to_string(),
             node_type: NodeType::CliProver as i32,
+            ed25519_public_key: verifying_key.to_bytes().to_vec(),
         };
 
-        match self
-            .make_request::<GetProofTaskRequest, GetProofTaskResponse>(
-                "/tasks",
-                Method::POST,
-                &request,
-            )
-            .await?
-        {
-            Some(get_proof_task_response) => Ok(Task::from(&get_proof_task_response)),
-            None => Err(OrchestratorError::ResponseError(
-                "No task found".to_string(),
-            )),
+        let request_bytes = request.encode_to_vec();
+        let url = format!("{}/v3/tasks", self.environment.orchestrator_url());
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/octet-stream")
+            .body(request_bytes)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(OrchestratorError::HTTPError {
+                status: response.status().as_u16(),
+                message: response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "Failed to read response text".to_string()),
+            });
         }
+
+        // Decode the response bytes
+        let response_bytes = response.bytes().await?;
+        let get_proof_task_response: GetProofTaskResponse =
+            match GetProofTaskResponse::decode(response_bytes) {
+                Ok(msg) => msg,
+                Err(_e) => return Err(OrchestratorError::DecodeError(_e)),
+            };
+        Ok(Task::from(&get_proof_task_response))
     }
 
     async fn submit_proof(
@@ -226,24 +260,64 @@ impl Orchestrator for OrchestratorClient {
 }
 
 #[cfg(test)]
-mod tests {
+/// These are ignored by default since they require a live orchestrator to run.
+mod live_orchestrator_tests {
     use crate::environment::Environment;
     use crate::orchestrator::Orchestrator;
-    use tokio::test;
 
-    #[test]
-    #[ignore] // Ignored because it queries a live orchestrator.
-    // Should return a list of tasks for the node.
+    #[tokio::test]
+    #[ignore] // This test requires a live orchestrator instance.
+    /// Should register a new user with the orchestrator.
+    async fn test_register_user() {
+        let client = super::OrchestratorClient::new(Environment::Beta);
+        // UUIDv4 for the user ID
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let wallet_address = "0x1234567890abcdef1234567890abcabc12345678"; // Example wallet address
+        match client.register_user(&user_id, wallet_address).await {
+            Ok(_) => println!("User registered successfully: {}", user_id),
+            Err(e) => panic!("Failed to register user: {}", e),
+        }
+    }
+
+    #[tokio::test]
+    #[ignore] // This test requires a live orchestrator instance.
+    /// Should register a new node to an existing user.
+    async fn test_register_node() {
+        let client = super::OrchestratorClient::new(Environment::Beta);
+        let user_id = "78db0be7-f603-4511-9576-c660f3c58395";
+        match client.register_node(user_id).await {
+            Ok(node_id) => println!("Node registered successfully: {}", node_id),
+            Err(e) => panic!("Failed to register node: {}", e),
+        }
+    }
+
+    #[tokio::test]
+    #[ignore] // This test requires a live orchestrator instance.
+    /// Should return a new proof task for the node.
+    async fn test_get_proof_task() {
+        let client = super::OrchestratorClient::new(Environment::Beta);
+        let node_id = "5880437"; // Example node ID
+        let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
+        let verifying_key = signing_key.verifying_key();
+        let result = client.get_proof_task(node_id, verifying_key).await;
+        println!("{:?}", result);
+    }
+
+    #[tokio::test]
+    /// Should return the list of existing tasks for the node.
     async fn test_get_tasks() {
         let client = super::OrchestratorClient::new(Environment::Beta);
-
-        for node_id in 1000..2000 {
-            let result = client.get_tasks(&node_id.to_string()).await;
-            println!("{:?}", result);
+        let node_id = "5880437"; // Example node ID
+        match client.get_tasks(&node_id.to_string()).await {
+            Ok(tasks) => {
+                println!("Retrieved {} tasks for node {}", tasks.len(), node_id);
+                for task in &tasks {
+                    println!("Task: {}", task);
+                }
+            }
+            Err(e) => {
+                panic!("Failed to get tasks: {}", e);
+            }
         }
-
-        // let node_id = 102;
-        // let tasks = client.get_tasks(&node_id.to_string()).await;
-        // assert!(tasks.is_ok(), "Failed to get tasks: {:?}", tasks.err());
     }
 }

--- a/clients/cli/src/orchestrator/error.rs
+++ b/clients/cli/src/orchestrator/error.rs
@@ -5,10 +5,6 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum OrchestratorError {
-    /// Failed to read or interpret the server's response.
-    #[error("Invalid response from server: {0}")]
-    ResponseError(String),
-
     /// Failed to decode a Protobuf message from the server
     #[error("Decoding error: {0}")]
     DecodeError(#[from] DecodeError),

--- a/clients/cli/src/orchestrator/mod.rs
+++ b/clients/cli/src/orchestrator/mod.rs
@@ -1,7 +1,7 @@
 use crate::environment::Environment;
 use crate::orchestrator::error::OrchestratorError;
 use crate::task::Task;
-use ed25519_dalek::SigningKey;
+use ed25519_dalek::{SigningKey, VerifyingKey};
 
 mod client;
 pub use client::OrchestratorClient;
@@ -25,8 +25,12 @@ pub trait Orchestrator {
     /// Get the list of tasks currently assigned to the node.
     async fn get_tasks(&self, node_id: &str) -> Result<Vec<Task>, OrchestratorError>;
 
-    /// Retrieves a proof task for the node.
-    async fn get_proof_task(&self, node_id: &str) -> Result<Task, OrchestratorError>;
+    /// Request a new proof task for the node.
+    async fn get_proof_task(
+        &self,
+        node_id: &str,
+        verifying_key: VerifyingKey,
+    ) -> Result<Task, OrchestratorError>;
 
     /// Submits a proof to the orchestrator.
     async fn submit_proof(

--- a/clients/cli/src/proto/nexus.orchestrator.rs
+++ b/clients/cli/src/proto/nexus.orchestrator.rs
@@ -63,6 +63,9 @@ pub struct GetProofTaskRequest {
     /// The type of this node.
     #[prost(enumeration = "NodeType", tag = "2")]
     pub node_type: i32,
+    /// The client's Ed25519 public key for proof authentication.Add commentMore actions
+    #[prost(bytes = "vec", tag = "3")]
+    pub ed25519_public_key: ::prost::alloc::vec::Vec<u8>,
 }
 /// A Prover task.
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -32,8 +32,9 @@ pub async fn authenticated_proving(
     stwo_prover: Stwo<Local>,
     signing_key: SigningKey,
 ) -> Result<(), ProverError> {
+    let verifying_key = signing_key.verifying_key();
     let task = orchestrator_client
-        .get_proof_task(&node_id.to_string())
+        .get_proof_task(&node_id.to_string(), verifying_key)
         .await
         .map_err(|e| ProverError::Orchestrator(format!("Failed to fetch proof task: {}", e)))?;
 

--- a/proto/orchestrator.proto
+++ b/proto/orchestrator.proto
@@ -68,6 +68,9 @@ message GetProofTaskRequest {
 
   // The type of this node.
   NodeType node_type = 2;
+
+  // The client's Ed25519 public key for proof authentication.Add commentMore actions
+  bytes ed25519PublicKey = 3;
 }
 
 // A Prover task.


### PR DESCRIPTION
Syncs the local copy of orchestrator.proto with the file currently in use by the orchestrator. Specifically, GetProofTaskRequest now must include the node's public key.

Adds tests that query a live instance of the orchestrator. These are ignored for now, with the intent that they can be run manually.  Eventually, I'd like to turn them into proper integration tests.

Fixes: https://linear.app/nexus-labs/issue/NET-1340/cli-update-getprooftask-proto-message-to-include-public-key