### PR TITLE
feat: Worker threads consume from a central task queue

### DIFF
--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "nexus-network"
-version = "0.8.3"
+version = "0.8.5"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -455,16 +455,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
-name = "colored"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
-dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,28 +520,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,15 +534,6 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1566,12 +1525,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,14 +1627,11 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
- "colored",
- "crossbeam",
  "crossterm 0.29.0",
  "ed25519-dalek",
  "home",
  "iana-time-zone",
  "log",
- "md5",
  "mockall",
  "nexus-sdk",
  "postcard",

--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -822,6 +822,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,6 +995,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "futures-channel"
@@ -1602,6 +1614,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,6 +1682,7 @@ dependencies = [
  "iana-time-zone",
  "log",
  "md5",
+ "mockall",
  "nexus-sdk",
  "postcard",
  "predicates",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-network"
-version = "0.8.3"
+version = "0.8.5"
 edition = "2024"
 rust-version = "1.85"
 build = "build.rs"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -27,8 +27,6 @@ incremental = true
 [dependencies]
 chrono = "0.4.38"
 clap = { version = "4.5", features = ["derive"] }
-colored = "2.1.0"
-crossbeam = "0.8.4"
 crossterm = "0.29.0"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 rand = "0.8"
@@ -36,7 +34,6 @@ rand_core = "0.6"
 home = "0.5.9"
 iana-time-zone = "0.1.60"
 log = "0.4.26"
-md5 = "0.7.0"
 nexus-sdk = { git = "https://github.com/nexus-xyz/nexus-zkvm", tag = "0.3.4" }
 postcard = "1.0.10"
 prost = "0.13"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -55,6 +55,8 @@ prost-types = "0.13.5"
 
 [dev-dependencies]
 assert_cmd = "2"
+async-trait = "0.1.88"
+mockall = "0.12"
 predicates = "3"
 tempfile = "3.20.0"
 

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     }
                 }
             }
-            start(node_id, environment, max_threads)
+            start(node_id, environment, max_threads).await
         }
         Command::Logout => {
             println!("Logging out and clearing node configuration file...");
@@ -184,7 +184,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 /// * `node_id` - This client's unique identifier, if available.
 /// * `env` - The environment to connect to.
 /// * `max_threads` - Optional maximum number of threads to use for proving.
-fn start(
+async fn start(
     node_id: Option<u64>,
     env: Environment,
     _max_threads: Option<u32>,
@@ -204,7 +204,10 @@ fn start(
     let mut csprng = rand_core::OsRng;
     let signing_key: SigningKey = SigningKey::generate(&mut csprng);
     let app = ui::App::new(node_id, orchestrator_client, signing_key);
-    let res = ui::run(&mut terminal, app);
+    // let res = ui::run(&mut terminal, app);
+
+    let res = ui::run(&mut terminal, app) // this call must now be `async fn run()`
+        .await;
 
     // Clean up the terminal after running the application.
     disable_raw_mode()?;

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -8,6 +8,7 @@ mod keys;
 mod nexus_orchestrator;
 mod orchestrator;
 mod prover;
+mod prover_runtime;
 pub mod system;
 mod task;
 mod ui;

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -13,17 +13,17 @@ pub mod system;
 mod task;
 mod ui;
 
-use crate::config::{Config, get_config_path};
+use crate::config::{get_config_path, Config};
 use crate::environment::Environment;
 use crate::orchestrator::{Orchestrator, OrchestratorClient};
 use clap::{Parser, Subcommand};
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},
     execute,
-    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ed25519_dalek::SigningKey;
-use ratatui::{Terminal, backend::CrosstermBackend};
+use ratatui::{backend::CrosstermBackend, Terminal};
 use std::{error::Error, io};
 
 #[derive(Parser)]
@@ -220,5 +220,6 @@ async fn start(
     terminal.show_cursor()?;
 
     res?;
+    println!("Nexus CLI application exited successfully.");
     Ok(())
 }

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -13,17 +13,17 @@ pub mod system;
 mod task;
 mod ui;
 
-use crate::config::{get_config_path, Config};
+use crate::config::{Config, get_config_path};
 use crate::environment::Environment;
 use crate::orchestrator::{Orchestrator, OrchestratorClient};
 use clap::{Parser, Subcommand};
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},
     execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use ed25519_dalek::SigningKey;
-use ratatui::{backend::CrosstermBackend, Terminal};
+use ratatui::{Terminal, backend::CrosstermBackend};
 use std::{error::Error, io};
 
 #[derive(Parser)]

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -13,17 +13,17 @@ pub mod system;
 mod task;
 mod ui;
 
-use crate::config::{Config, get_config_path};
+use crate::config::{get_config_path, Config};
 use crate::environment::Environment;
 use crate::orchestrator::{Orchestrator, OrchestratorClient};
 use clap::{Parser, Subcommand};
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},
     execute,
-    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ed25519_dalek::SigningKey;
-use ratatui::{Terminal, backend::CrosstermBackend};
+use ratatui::{backend::CrosstermBackend, Terminal};
 use std::{error::Error, io};
 
 #[derive(Parser)]
@@ -205,8 +205,6 @@ async fn start(
     let mut csprng = rand_core::OsRng;
     let signing_key: SigningKey = SigningKey::generate(&mut csprng);
     let app = ui::App::new(node_id, orchestrator_client, signing_key);
-    // let res = ui::run(&mut terminal, app);
-
     let res = ui::run(&mut terminal, app) // this call must now be `async fn run()`
         .await;
 

--- a/clients/cli/src/orchestrator/mod.rs
+++ b/clients/cli/src/orchestrator/mod.rs
@@ -7,9 +7,13 @@ mod client;
 pub use client::OrchestratorClient;
 pub mod error;
 
-#[async_trait::async_trait]
+#[cfg(test)]
+use mockall::{automock, mock, predicate::*};
+
 #[allow(dead_code)]
-pub trait Orchestrator {
+#[cfg_attr(test, automock)]
+#[async_trait::async_trait]
+pub trait Orchestrator: Send + Sync {
     fn environment(&self) -> &Environment;
 
     /// Registers a new user with the orchestrator.

--- a/clients/cli/src/orchestrator/mod.rs
+++ b/clients/cli/src/orchestrator/mod.rs
@@ -10,7 +10,6 @@ pub mod error;
 #[cfg(test)]
 use mockall::{automock, predicate::*};
 
-#[allow(dead_code)]
 #[cfg_attr(test, automock)]
 #[async_trait::async_trait]
 pub trait Orchestrator: Send + Sync {

--- a/clients/cli/src/orchestrator/mod.rs
+++ b/clients/cli/src/orchestrator/mod.rs
@@ -8,7 +8,7 @@ pub use client::OrchestratorClient;
 pub mod error;
 
 #[cfg(test)]
-use mockall::{automock, mock, predicate::*};
+use mockall::{automock, predicate::*};
 
 #[allow(dead_code)]
 #[cfg_attr(test, automock)]

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -1,7 +1,7 @@
 use crate::task::Task;
 use log::error;
 use nexus_sdk::stwo::seq::Proof;
-use nexus_sdk::{Local, Prover, Viewable, stwo::seq::Stwo};
+use nexus_sdk::{stwo::seq::Stwo, Local, Prover, Viewable};
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -1,7 +1,7 @@
 use crate::task::Task;
 use log::error;
 use nexus_sdk::stwo::seq::Proof;
-use nexus_sdk::{stwo::seq::Stwo, KnownExitCodes, Local, Prover, Viewable};
+use nexus_sdk::{KnownExitCodes, Local, Prover, Viewable, stwo::seq::Stwo};
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -1,7 +1,7 @@
 use crate::task::Task;
 use log::error;
 use nexus_sdk::stwo::seq::Proof;
-use nexus_sdk::{stwo::seq::Stwo, Local, Prover, Viewable};
+use nexus_sdk::{Local, Prover, Viewable, stwo::seq::Stwo};
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -1,7 +1,7 @@
 use crate::task::Task;
 use log::error;
 use nexus_sdk::stwo::seq::Proof;
-use nexus_sdk::{KnownExitCodes, Local, Prover, Viewable, stwo::seq::Stwo};
+use nexus_sdk::{stwo::seq::Stwo, KnownExitCodes, Local, Prover, Viewable};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -45,8 +45,7 @@ pub fn prove_anonymously() -> Result<Proof, ProverError> {
 
 /// Proves a program with a given node ID
 pub async fn authenticated_proving(task: &Task) -> Result<Proof, ProverError> {
-    let public_input = get_public_input(&task)?;
-
+    let public_input = get_public_input(task)?;
     let stwo_prover = get_default_stwo_prover()?;
     let (view, proof) = stwo_prover
         .prove_with_input::<(), u32>(&(), &public_input)

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -6,9 +6,6 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ProverError {
-    #[error("Orchestrator error: {0}")]
-    Orchestrator(String),
-
     #[error("Stwo prover error: {0}")]
     Stwo(String),
 
@@ -17,6 +14,7 @@ pub enum ProverError {
 }
 
 /// Proves a program locally with hardcoded inputs.
+#[allow(unused)]
 pub fn prove_anonymously() -> Result<(), ProverError> {
     let stwo_prover = get_default_stwo_prover()?;
     // The 10th term of the Fibonacci sequence is 55

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -1,7 +1,7 @@
 use crate::task::Task;
 use log::error;
 use nexus_sdk::stwo::seq::Proof;
-use nexus_sdk::{Local, Prover, Viewable, stwo::seq::Stwo};
+use nexus_sdk::{stwo::seq::Stwo, Local, Prover, Viewable};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -41,7 +41,7 @@ pub fn prove_anonymously() -> Result<Proof, ProverError> {
 
 /// Proves a program with a given node ID
 pub async fn authenticated_proving(
-    task: Task,
+    task: &Task,
     stwo_prover: Stwo<Local>,
 ) -> Result<Proof, ProverError> {
     let public_input: u32 = task.public_inputs.first().cloned().unwrap_or_default() as u32;
@@ -85,7 +85,8 @@ mod tests {
     #[tokio::test]
     // Proves a program with hardcoded inputs should succeed.
     async fn test_prove_anonymously() {
-        let result = prove_anonymously();
-        assert!(result.is_ok(), "Anonymous proving failed: {:?}", result);
+        if let Err(e) = prove_anonymously() {
+            panic!("Failed to prove anonymously: {}", e);
+        }
     }
 }

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -1,5 +1,5 @@
 use crate::task::Task;
-use log::{error, info, warn};
+use log::error;
 use nexus_sdk::stwo::seq::Proof;
 use nexus_sdk::{Local, Prover, Viewable, stwo::seq::Stwo};
 use thiserror::Error;
@@ -27,7 +27,6 @@ pub fn prove_anonymously() -> Result<(), ProverError> {
 
 /// Proves a program with a given node ID
 pub async fn authenticated_proving(
-    node_id: u64,
     task: Task,
     stwo_prover: Stwo<Local>,
 ) -> Result<Proof, ProverError> {
@@ -44,16 +43,6 @@ pub async fn authenticated_proving(
     assert_eq!(exit_code, 0, "Unexpected exit code!");
 
     Ok(proof)
-
-    // let proof_bytes = prove_helper(stwo_prover, public_input)?;
-    // let proof_hash = format!("{:x}", Keccak256::digest(&proof_bytes));
-    // orchestrator_client
-    //     .submit_proof(&task.task_id, &proof_hash, proof_bytes, signing_key)
-    //     .await
-    //     .map_err(|e| ProverError::Orchestrator(format!("Failed to submit proof: {}", e)))?;
-    //
-    // info!("{}", "ZK proof successfully submitted".green());
-    // Ok(())
 }
 
 /// Create a Stwo prover for the default program.

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -14,7 +14,6 @@ pub enum ProverError {
 }
 
 /// Proves a program locally with hardcoded inputs.
-#[allow(unused)]
 pub fn prove_anonymously() -> Result<Proof, ProverError> {
     // The 10th term of the Fibonacci sequence is 55
     let public_input: u32 = 9;

--- a/clients/cli/src/prover_runtime.rs
+++ b/clients/cli/src/prover_runtime.rs
@@ -219,25 +219,6 @@ pub async fn fetch_prover_tasks(
     }
 }
 
-// /// Submits proofs to the orchestrator
-// pub async fn submit_proofs(
-//     signing_key: SigningKey,
-//     orchestrator: Box<dyn Orchestrator>,
-//     mut results: Receiver<(Task, Proof)>,
-// ) -> JoinHandle<()> {
-//     tokio::spawn(async move {
-//         while let Some((task, proof)) = results.recv().await {
-//             let proof_bytes = postcard::to_allocvec(&proof).expect("Failed to serialize proof");
-//             let proof_hash = format!("{:x}", Keccak256::digest(&proof_bytes));
-//
-//             // TODO: Handle error
-//             let _res = orchestrator
-//                 .submit_proof(&task.task_id, &proof_hash, proof_bytes, signing_key.clone())
-//                 .await;
-//         }
-//     })
-// }
-
 /// Submits proofs to the orchestrator
 pub async fn submit_proofs(
     signing_key: SigningKey,
@@ -274,24 +255,6 @@ pub async fn submit_proofs(
         }
     })
 }
-
-// /// Spawns a dispatcher that forwards tasks to available workers in round-robin fashion.
-// pub fn start_dispatcher(
-//     mut task_receiver: Receiver<Task>,
-//     worker_senders: Vec<Sender<Task>>,
-//     mut shutdown: broadcast::Receiver<()>,
-// ) -> JoinHandle<()> {
-//     tokio::spawn(async move {
-//         let mut next_worker = 0;
-//         while let Some(task) = task_receiver.recv().await {
-//             let target = next_worker % worker_senders.len();
-//             if (worker_senders[target].send(task).await).is_err() {
-//                 eprintln!("Dispatcher: worker {} channel closed", target);
-//             }
-//             next_worker += 1;
-//         }
-//     })
-// }
 
 /// Spawns a dispatcher that forwards tasks to available workers in round-robin fashion.
 pub fn start_dispatcher(

--- a/clients/cli/src/prover_runtime.rs
+++ b/clients/cli/src/prover_runtime.rs
@@ -377,7 +377,7 @@ pub fn start_workers(
 #[cfg(test)]
 mod tests {
     use crate::orchestrator::MockOrchestrator;
-    use crate::prover_runtime::fetch_prover_tasks;
+    use crate::prover_runtime::{fetch_prover_tasks, WorkerEvent};
     use crate::task::Task;
     use std::time::Duration;
     use tokio::sync::{broadcast, mpsc};
@@ -408,6 +408,7 @@ mod tests {
 
         // Run task_master in a tokio task to stay in the same thread context
         let (shutdown_sender, _) = broadcast::channel(1); // Only one shutdown signal needed
+        let (event_sender, _event_receiver) = mpsc::channel::<WorkerEvent>(100);
         let shutdown_receiver = shutdown_sender.subscribe();
         let task_master_handle = tokio::spawn(async move {
             fetch_prover_tasks(
@@ -415,6 +416,7 @@ mod tests {
                 verifying_key,
                 orchestrator_client,
                 task_sender,
+                event_sender,
                 shutdown_receiver,
             )
             .await;

--- a/clients/cli/src/prover_runtime.rs
+++ b/clients/cli/src/prover_runtime.rs
@@ -128,7 +128,7 @@ pub async fn start_anonymous_workers(
                                 let now = Local::now();
                                 let timestamp = now.format("%Y-%m-%d %H:%M:%S").to_string();
                                 let message = format!(
-                                    "✅ [{}] Anonymous proof completed successfully [Worker {}]",
+                                    "✅ [{}] Anonymous proof completed successfully (Prover {})",
                                     timestamp, worker_id
                                 );
                                 let _ = prover_event_sender.send(WorkerEvent::Prover {
@@ -172,9 +172,11 @@ pub async fn fetch_prover_tasks(
             _ = tokio::time::sleep(Duration::from_millis(100)) => {
                 // Get existing tasks.
                 if fetch_existing_tasks {
+                    let now = Local::now();
+                    let timestamp = now.format("%Y-%m-%d %H:%M:%S").to_string();
                     match orchestrator_client.get_tasks(&node_id.to_string()).await {
                         Ok(tasks) => {
-                            let msg = format!("🔄 Fetched {} tasks", tasks.len());
+                            let msg = format!("🔄 [{}] Fetched {} tasks", timestamp, tasks.len());
                             let _ = event_sender
                                         .send(WorkerEvent::TaskFetcher { data: msg })
                                         .await;
@@ -188,7 +190,7 @@ pub async fn fetch_prover_tasks(
                             fetch_existing_tasks = false;
                         }
                         Err(e) => {
-                            let message = format!("⚠️ Failed to fetch existing tasks: {}", e);
+                            let message = format!("⚠️ [{}] Failed to fetch existing tasks: {}", timestamp, e);
                             let _ = event_sender
                                 .send(WorkerEvent::TaskFetcher { data: message })
                                 .await;
@@ -364,7 +366,7 @@ pub fn start_workers(
                         match authenticated_proving(&task).await {
                             Ok(proof) => {
                                 let message = format!(
-                                    "✅ [{}] Proof completed successfully [Prover {}]",
+                                    "✅ [{}] Proof completed successfully (Prover {})",
                                     timestamp, worker_id
                                 );
                                 let _ = prover_event_sender

--- a/clients/cli/src/prover_runtime.rs
+++ b/clients/cli/src/prover_runtime.rs
@@ -377,7 +377,7 @@ pub fn start_workers(
 #[cfg(test)]
 mod tests {
     use crate::orchestrator::MockOrchestrator;
-    use crate::prover_runtime::{fetch_prover_tasks, WorkerEvent};
+    use crate::prover_runtime::{WorkerEvent, fetch_prover_tasks};
     use crate::task::Task;
     use std::time::Duration;
     use tokio::sync::{broadcast, mpsc};

--- a/clients/cli/src/prover_runtime.rs
+++ b/clients/cli/src/prover_runtime.rs
@@ -16,7 +16,7 @@ use ed25519_dalek::{SigningKey, VerifyingKey};
 use nexus_sdk::stwo::seq::Proof;
 use sha3::{Digest, Keccak256};
 use std::time::Duration;
-use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tokio::sync::mpsc::{Receiver, Sender, channel};
 use tokio::task::JoinHandle;
 
 /// Events emitted by prover (worker) threads.

--- a/clients/cli/src/prover_runtime.rs
+++ b/clients/cli/src/prover_runtime.rs
@@ -401,7 +401,7 @@ pub fn start_workers(
 #[cfg(test)]
 mod tests {
     use crate::orchestrator::MockOrchestrator;
-    use crate::prover_runtime::{fetch_prover_tasks, WorkerEvent};
+    use crate::prover_runtime::{WorkerEvent, fetch_prover_tasks};
     use crate::task::Task;
     use std::time::Duration;
     use tokio::sync::{broadcast, mpsc};

--- a/clients/cli/src/prover_runtime.rs
+++ b/clients/cli/src/prover_runtime.rs
@@ -17,7 +17,7 @@ use ed25519_dalek::{SigningKey, VerifyingKey};
 use nexus_sdk::stwo::seq::Proof;
 use sha3::{Digest, Keccak256};
 use std::time::Duration;
-use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tokio::sync::mpsc::{Receiver, Sender, channel};
 use tokio::task::JoinHandle;
 
 /// Events emitted by prover (worker) threads.

--- a/clients/cli/src/prover_runtime.rs
+++ b/clients/cli/src/prover_runtime.rs
@@ -1,0 +1,265 @@
+//! Prover Runtime
+//!
+//! Handles background execution of proof tasks in both authenticated and anonymous modes.
+//! Spawns async workers, dispatches tasks, and reports progress back to the UI.
+//!
+//! Includes:
+//! - Task fetching from the orchestrator (authenticated mode)
+//! - Worker management and task dispatching
+//! - Prover event reporting
+
+use crate::orchestrator::Orchestrator;
+use crate::prover::authenticated_proving;
+use crate::task::Task;
+use chrono::Local;
+use ed25519_dalek::VerifyingKey;
+use nexus_sdk::stwo::seq::Proof;
+use std::time::Duration;
+use tokio::sync::mpsc::{Receiver, Sender, channel};
+use tokio::task::JoinHandle;
+
+/// Events emitted by prover (worker) threads.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ProverEvent {
+    Message {
+        worker_id: usize,
+        data: String,
+    },
+    #[allow(unused)]
+    Done {
+        worker_id: usize,
+    },
+}
+
+/// Starts authenticated workers that fetch tasks from the orchestrator and process them.
+pub fn start_authenticated_workers(
+    node_id: u64,
+    verifying_key: VerifyingKey,
+    orchestrator: Box<dyn Orchestrator>,
+    num_workers: usize,
+) -> Receiver<ProverEvent> {
+    // Task fetching
+    let task_queue_size = 100;
+    let (task_sender, task_receiver) = channel::<Task>(task_queue_size);
+    let _fetch_prover_tasks_handle = tokio::spawn(async move {
+        fetch_prover_tasks(node_id, verifying_key, orchestrator, task_sender).await;
+    });
+
+    // Workers
+    let (_result_sender, _result_receiver) = channel::<(Task, Proof)>(1000);
+    let (prover_event_sender, prover_event_receiver) = channel::<ProverEvent>(100);
+    let (worker_senders, _worker_handles) = start_workers(num_workers, prover_event_sender.clone());
+
+    // Dispatch tasks to workers
+    let _dispatcher_handle = start_dispatcher(task_receiver, worker_senders);
+
+    // TODO: Handle results from workers, e.g., send to orchestrator or store.
+
+    prover_event_receiver
+}
+
+/// Starts anonymous workers that repeatedly prove a program with hardcoded inputs.
+pub fn start_anonymous_workers(num_workers: usize) -> Receiver<ProverEvent> {
+    let (prover_event_sender, prover_event_receiver) = channel::<ProverEvent>(100);
+    for worker_id in 0..num_workers {
+        let prover_event_sender = prover_event_sender.clone();
+        tokio::spawn(async move {
+            loop {
+                match crate::prover::prove_anonymously() {
+                    Ok(_proof) => {
+                        let now = Local::now();
+                        let timestamp = now.format("%Y-%m-%d %H:%M:%S").to_string();
+                        let message = format!(
+                            "✅ [{}] Anonymous proof completed successfully [Worker {}]",
+                            timestamp, worker_id
+                        );
+                        let _ = prover_event_sender
+                            .send(ProverEvent::Message {
+                                worker_id,
+                                data: message,
+                            })
+                            .await;
+                    }
+                    Err(e) => {
+                        let message = format!("Anonymous Worker {}: Error - {}", worker_id, e);
+                        let _ = prover_event_sender
+                            .send(ProverEvent::Message {
+                                worker_id,
+                                data: message,
+                            })
+                            .await;
+                    }
+                }
+                // Optional cooldown to avoid spamming
+                tokio::time::sleep(Duration::from_millis(300)).await;
+            }
+        });
+    }
+
+    prover_event_receiver
+}
+
+/// Fetches tasks from the orchestrator and place them in the task queue.
+pub async fn fetch_prover_tasks(
+    node_id: u64,
+    verifying_key: VerifyingKey,
+    orchestrator_client: Box<dyn Orchestrator>,
+    sender: Sender<Task>,
+) {
+    loop {
+        match orchestrator_client
+            .get_proof_task(&node_id.to_string(), verifying_key)
+            .await
+        {
+            Ok(task) => {
+                if sender.send(task).await.is_err() {
+                    println!("sender.send() failed, task queue is closed");
+                    return;
+                }
+            }
+            Err(e) => {
+                println!("Failed to fetch task: {}", e);
+            }
+        }
+        // Be polite to the orchestrator and wait a bit before fetching the next task.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+/// Spawns a dispatcher that forwards tasks to available workers in round-robin fashion.
+pub fn start_dispatcher(
+    mut task_receiver: Receiver<Task>,
+    worker_senders: Vec<Sender<Task>>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut next_worker = 0;
+        while let Some(task) = task_receiver.recv().await {
+            let target = next_worker % worker_senders.len();
+            if (worker_senders[target].send(task).await).is_err() {
+                eprintln!("Dispatcher: worker {} channel closed", target);
+            }
+            next_worker += 1;
+        }
+    })
+}
+
+/// Spawns a set of worker tasks that receive tasks and send prover events.
+///
+/// # Arguments
+/// * `num_workers` - The number of worker tasks to spawn.
+/// * `prover_event_sender` - The channel to send prover events to the main thread.
+///
+/// # Returns
+/// A tuple containing:
+/// * A vector of `Sender<Task>` for each worker, allowing tasks to be sent to them.
+/// * A vector of `JoinHandle<()>` for each worker, allowing the main thread to await their completion.
+pub fn start_workers(
+    num_workers: usize,
+    prover_event_sender: Sender<ProverEvent>,
+) -> (Vec<Sender<Task>>, Vec<JoinHandle<()>>) {
+    let mut senders = Vec::with_capacity(num_workers);
+    let mut handles = Vec::with_capacity(num_workers);
+
+    for worker_id in 0..num_workers {
+        let (task_sender, mut task_receiver) = tokio::sync::mpsc::channel::<Task>(8);
+        let prover_event_sender = prover_event_sender.clone();
+
+        let handle = tokio::spawn(async move {
+            while let Some(task) = task_receiver.recv().await {
+                let stwo_prover =
+                    crate::prover::get_default_stwo_prover().expect("Failed to create prover");
+                match authenticated_proving(task, stwo_prover).await {
+                    Ok(_proof) => {
+                        let now = Local::now();
+                        let timestamp = now.format("%Y-%m-%d %H:%M:%S").to_string();
+                        let message = format!(
+                            "✅ [{}] Proof completed successfully [Prover {}]",
+                            timestamp, worker_id
+                        );
+                        let _ = prover_event_sender
+                            .send(ProverEvent::Message {
+                                worker_id,
+                                data: message,
+                            })
+                            .await;
+                        // TODO: Handle the proof (e.g., send to orchestrator, store, etc.)
+                    }
+                    Err(e) => {
+                        let message = format!("Worker {}: Error - {}", worker_id, e);
+                        let _ = prover_event_sender
+                            .send(ProverEvent::Message {
+                                worker_id,
+                                data: message,
+                            })
+                            .await;
+                    }
+                }
+            }
+        });
+
+        senders.push(task_sender);
+        handles.push(handle);
+    }
+
+    (senders, handles)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::orchestrator::MockOrchestrator;
+    use crate::prover_runtime::fetch_prover_tasks;
+    use crate::task::Task;
+    use std::time::Duration;
+    use tokio::sync::mpsc;
+
+    /// Creates a mock orchestrator client that simulates fetching tasks.
+    fn get_mock_orchestrator_client() -> MockOrchestrator {
+        let mut i = 0;
+        let mut mock = MockOrchestrator::new();
+        mock.expect_get_proof_task().returning_st(move |_, _| {
+            // Simulate a task with dummy data
+            let task = Task::new(i.to_string(), format!("Task {}", i), vec![1, 2, 3]);
+            i += 1;
+            Ok(task)
+        });
+        mock
+    }
+
+    #[tokio::test]
+    // Should fetch and enqueue tasks from the orchestrator.
+    async fn test_task_fetching() {
+        let orchestrator_client = Box::new(get_mock_orchestrator_client());
+        let signer_key = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let verifying_key = signer_key.verifying_key();
+        let node_id = 1234;
+
+        let task_queue_size = 10;
+        let (task_sender, mut task_receiver) = mpsc::channel::<Task>(task_queue_size);
+
+        // Run task_master in a tokio task to stay in the same thread context
+        let task_master_handle = tokio::spawn(async move {
+            fetch_prover_tasks(node_id, verifying_key, orchestrator_client, task_sender).await;
+        });
+
+        // Receive tasks
+        let mut received = 0;
+        for _i in 0..task_queue_size {
+            match tokio::time::timeout(Duration::from_secs(2), task_receiver.recv()).await {
+                Ok(Some(task)) => {
+                    println!("Received task {}: {:?}", received, task);
+                    received += 1;
+                }
+                Ok(None) => {
+                    eprintln!("Channel closed unexpectedly");
+                    break;
+                }
+                Err(_) => {
+                    eprintln!("Timed out waiting for task {}", received);
+                    break;
+                }
+            }
+        }
+
+        task_master_handle.abort();
+    }
+}

--- a/clients/cli/src/ui/dashboard.rs
+++ b/clients/cli/src/ui/dashboard.rs
@@ -2,11 +2,11 @@
 
 use crate::environment::Environment;
 use crate::system;
-use crate::ui::ProverEvent;
-use ratatui::Frame;
+use crate::ui::WorkerEvent;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout};
 use ratatui::prelude::{Color, Modifier, Style};
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
+use ratatui::Frame;
 use std::collections::VecDeque;
 use std::time::Instant;
 
@@ -35,7 +35,7 @@ pub struct DashboardState {
     pub total_ram_gb: f64,
 
     /// A queue of events received from worker threads.
-    pub events: VecDeque<ProverEvent>,
+    pub events: VecDeque<WorkerEvent>,
 }
 
 impl DashboardState {
@@ -49,7 +49,7 @@ impl DashboardState {
         node_id: Option<u64>,
         environment: Environment,
         start_time: Instant,
-        events: &VecDeque<ProverEvent>,
+        events: &VecDeque<WorkerEvent>,
     ) -> Self {
         Self {
             node_id,
@@ -170,12 +170,13 @@ pub fn render_dashboard(f: &mut Frame, state: &DashboardState) {
         .events
         .iter()
         .map(|event| match event {
-            ProverEvent::Message {
+            WorkerEvent::Prover {
                 worker_id: _worker_id,
                 data,
             } => data.to_string(),
-            ProverEvent::Done { worker_id } => {
-                format!("[{}] Task completed", worker_id)
+            WorkerEvent::TaskFetcher { data } => data.to_string(),
+            WorkerEvent::ProofSubmitter { data } => {
+                format!("[Proof Submitter] {}", data)
             }
         })
         .collect();

--- a/clients/cli/src/ui/dashboard.rs
+++ b/clients/cli/src/ui/dashboard.rs
@@ -11,6 +11,7 @@ use std::collections::VecDeque;
 use std::time::Instant;
 
 /// State for the dashboard screen, containing node information and menu items.
+#[derive(Debug, Clone)]
 pub struct DashboardState {
     /// Unique identifier for the node.
     pub node_id: Option<u64>,

--- a/clients/cli/src/ui/dashboard.rs
+++ b/clients/cli/src/ui/dashboard.rs
@@ -3,10 +3,10 @@
 use crate::environment::Environment;
 use crate::system;
 use crate::ui::WorkerEvent;
-use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout};
 use ratatui::prelude::{Color, Modifier, Style};
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
+use ratatui::Frame;
 use std::collections::VecDeque;
 use std::time::Instant;
 
@@ -175,9 +175,7 @@ pub fn render_dashboard(f: &mut Frame, state: &DashboardState) {
                 data,
             } => data.to_string(),
             WorkerEvent::TaskFetcher { data } => data.to_string(),
-            WorkerEvent::ProofSubmitter { data } => {
-                format!("[Proof Submitter] {}", data)
-            }
+            WorkerEvent::ProofSubmitter { data } => data.to_string(),
         })
         .collect();
 

--- a/clients/cli/src/ui/dashboard.rs
+++ b/clients/cli/src/ui/dashboard.rs
@@ -3,10 +3,10 @@
 use crate::environment::Environment;
 use crate::system;
 use crate::ui::WorkerEvent;
+use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout};
 use ratatui::prelude::{Color, Modifier, Style};
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
-use ratatui::Frame;
 use std::collections::VecDeque;
 use std::time::Instant;
 

--- a/clients/cli/src/ui/mod.rs
+++ b/clients/cli/src/ui/mod.rs
@@ -4,13 +4,13 @@ mod splash;
 
 use crate::environment::Environment;
 use crate::orchestrator::{Orchestrator, OrchestratorClient};
-use crate::prover_runtime::{ProverEvent, start_anonymous_workers, start_authenticated_workers};
-use crate::ui::dashboard::{DashboardState, render_dashboard};
+use crate::prover_runtime::{start_anonymous_workers, start_authenticated_workers, ProverEvent};
+use crate::ui::dashboard::{render_dashboard, DashboardState};
 use crate::ui::login::render_login;
 use crate::ui::splash::render_splash;
 use crossterm::event::{self, Event, KeyCode};
 use ed25519_dalek::SigningKey;
-use ratatui::{Frame, Terminal, backend::Backend};
+use ratatui::{backend::Backend, Frame, Terminal};
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
@@ -86,7 +86,7 @@ pub async fn run<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> std::i
     let splash_start = Instant::now();
     let splash_duration = Duration::from_secs(2);
 
-    let num_workers = 2; // TODO: Keep this low for now to avoid hitting rate limits.
+    let num_workers = 3; // TODO: Keep this low for now to avoid hitting rate limits.
 
     // Receives events from prover worker threads.
     let mut prover_event_receiver = match app.node_id {

--- a/clients/cli/src/ui/mod.rs
+++ b/clients/cli/src/ui/mod.rs
@@ -113,8 +113,8 @@ pub fn run<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> std::io::Res
             Some(node_id) => spawn_prover(
                 worker_id,
                 node_id,
-                app.orchestrator_client.clone(),
                 app.signing_key.clone(),
+                task_receiver.clone(),
                 sender.clone(),
             ),
             None => spawn_anonymous_prover(worker_id, sender.clone()),
@@ -296,8 +296,8 @@ fn spawn_anonymous_prover(
 fn spawn_prover(
     worker_id: usize,
     node_id: u64,
-    orchestrator_client: OrchestratorClient,
     signing_key: SigningKey,
+    task_receiver: crossbeam::channel::Receiver<Task>,
     sender: crossbeam::channel::Sender<ProverEvent>,
 ) -> JoinHandle<()> {
     thread::spawn(move || {
@@ -309,7 +309,7 @@ fn spawn_prover(
                     crate::prover::get_default_stwo_prover().expect("Failed to create Stwo prover");
                 match authenticated_proving(
                     node_id,
-                    &orchestrator_client,
+                    task_receiver.clone(),
                     stwo_prover,
                     signing_key.clone(),
                 )

--- a/clients/cli/src/ui/mod.rs
+++ b/clients/cli/src/ui/mod.rs
@@ -4,13 +4,13 @@ mod splash;
 
 use crate::environment::Environment;
 use crate::orchestrator::{Orchestrator, OrchestratorClient};
-use crate::prover_runtime::{start_anonymous_workers, start_authenticated_workers, WorkerEvent};
-use crate::ui::dashboard::{render_dashboard, DashboardState};
+use crate::prover_runtime::{WorkerEvent, start_anonymous_workers, start_authenticated_workers};
+use crate::ui::dashboard::{DashboardState, render_dashboard};
 use crate::ui::login::render_login;
 use crate::ui::splash::render_splash;
 use crossterm::event::{self, Event, KeyCode};
 use ed25519_dalek::SigningKey;
-use ratatui::{backend::Backend, Frame, Terminal};
+use ratatui::{Frame, Terminal, backend::Backend};
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast;

--- a/clients/cli/src/ui/mod.rs
+++ b/clients/cli/src/ui/mod.rs
@@ -4,7 +4,7 @@ mod splash;
 
 use crate::environment::Environment;
 use crate::orchestrator::{Orchestrator, OrchestratorClient};
-use crate::prover::{authenticated_proving, prove_anonymously};
+use crate::prover::authenticated_proving;
 use crate::task::Task;
 use crate::ui::dashboard::{DashboardState, render_dashboard};
 use crate::ui::login::render_login;
@@ -14,12 +14,9 @@ use crossterm::event::{self, Event, KeyCode};
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use ratatui::{Frame, Terminal, backend::Backend};
 use std::collections::VecDeque;
-use std::thread;
-use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
-use tokio::runtime::Runtime;
 use tokio::sync::mpsc::{Receiver, Sender, channel};
-use tokio::time::sleep;
+use tokio::task::JoinHandle;
 
 /// The different screens in the application.
 #[derive(Debug, Clone)]
@@ -80,6 +77,7 @@ impl App {
     }
 
     /// Handles a complete login process, transitioning to the dashboard screen.
+    #[allow(unused)]
     pub fn login(&mut self) {
         let node_id = Some(123); // Placeholder for node ID, replace with actual logic to get node ID
         let state = DashboardState::new(node_id, self.environment, self.start_time, &self.events);
@@ -92,78 +90,29 @@ pub async fn run<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> std::i
     let splash_start = Instant::now();
     let splash_duration = Duration::from_secs(2);
 
+    // TODO: prove anonymously if node_id is None
+
     // Create a task master that fetches tasks from the orchestrator
     let task_queue_size = 10;
-    let (task_sender, mut task_receiver) = channel::<Task>(task_queue_size);
+    let (task_sender, task_receiver) = channel::<Task>(task_queue_size);
     let verifying_key = app.signing_key.verifying_key();
-    let task_master_handle = tokio::spawn(async move {
+
+    // Spawn a Tokio task to fetch proving tasks from the orchestrator.
+    let _fetch_prover_tasks_handle = tokio::spawn(async move {
         let orchestrator_client = Box::new(app.orchestrator_client.clone());
         let node_id = app.node_id.expect("Node ID must be set");
-        task_master(node_id, verifying_key, orchestrator_client, task_sender).await;
+        fetch_prover_tasks(node_id, verifying_key, orchestrator_client, task_sender).await;
     });
-
-    // Create workers
-    let num_workers = 3; // TODO: Keep this low for now to avoid hitting rate limits.
 
     // Channel for sending events from workers to the main thread
     let (prover_event_sender, mut prover_event_receiver) = channel::<ProverEvent>(100);
-
-    // One channel per worker for sending tasks.
-    let mut worker_senders: Vec<Sender<Task>> = Vec::with_capacity(num_workers);
-
-    for worker_id in 0..num_workers {
-        let prover_event_sender = prover_event_sender.clone();
-        let (worker_sender, mut worker_receiver) = channel::<Task>(8);
-        worker_senders.push(worker_sender);
-        tokio::spawn(async move {
-            while let Some(task) = worker_receiver.recv().await {
-                let stwo_prover =
-                    crate::prover::get_default_stwo_prover().expect("Failed to create Stwo prover");
-                match authenticated_proving(task, stwo_prover).await {
-                    Ok(_) => {
-                        let now = Local::now();
-                        let timestamp = now.format("%Y-%m-%d %H:%M:%S").to_string();
-                        let message = format!(
-                            "✅ [{}] Proof completed successfully [Prover {}]",
-                            timestamp, worker_id
-                        );
-                        let _ = prover_event_sender
-                            .send(ProverEvent::Message {
-                                worker_id,
-                                data: message,
-                            })
-                            .await;
-                    }
-                    Err(e) => {
-                        let message = format!("Worker {}: Error - {}", worker_id, e);
-                        let _ = prover_event_sender
-                            .send(ProverEvent::Message {
-                                worker_id,
-                                data: message,
-                            })
-                            .await;
-                    }
-                }
-            }
-        });
-    }
+    let num_workers = 3; // TODO: Keep this low for now to avoid hitting rate limits.
+    let (worker_senders, _worker_handles) = start_workers(num_workers, prover_event_sender.clone());
 
     // Dispatch tasks to workers. This emulates a SPMC (Single Producer, Multiple Consumer) pattern.
-    tokio::spawn(async move {
-        let mut next_worker = 0;
-        while let Some(task) = task_receiver.recv().await {
-            let target = next_worker % worker_senders.len();
-            if let Err(_) = worker_senders[target].send(task).await {
-                eprintln!("Worker {} has closed channel", target);
-            }
-            next_worker += 1;
-        }
-        // println!("Dispatcher exiting");
-    });
+    let _dispatcher_handle = start_dispatcher(task_receiver, worker_senders);
 
-    // drop(sender); // Drop original sender to allow receiver to detect end-of-stream.
-    // let mut active_workers = num_workers;
-
+    // UI event loop
     loop {
         // Drain prover events from the async channel into app.events
         while let Ok(event) = prover_event_receiver.try_recv() {
@@ -241,23 +190,17 @@ fn render(f: &mut Frame, screen: &Screen) {
     match screen {
         Screen::Splash => render_splash(f),
         Screen::Login => render_login(f),
-        Screen::Dashboard(state) => {
-            // Update the dashboard state with the latest events
-            // let state =
-            //     DashboardState::new(app.node_id, app.environment, app.start_time, &app.events);
-            render_dashboard(f, &state)
-        }
+        Screen::Dashboard(state) => render_dashboard(f, state),
     }
 }
 
 /// Fetches tasks from the orchestrator and place them in the task queue.
-async fn task_master(
+async fn fetch_prover_tasks(
     node_id: u64,
     verifying_key: VerifyingKey,
     orchestrator_client: Box<dyn Orchestrator>,
     sender: Sender<Task>,
 ) {
-    println!("Task master started for node ID: {}", node_id);
     loop {
         match orchestrator_client
             .get_proof_task(&node_id.to_string(), verifying_key)
@@ -278,7 +221,7 @@ async fn task_master(
     }
 }
 
-/// Events emitted by prover threads.
+/// Events emitted by prover (worker) threads.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum ProverEvent {
     Message {
@@ -291,55 +234,31 @@ pub enum ProverEvent {
     },
 }
 
-/// Spawns a new thread for the anonymous prover.
-fn spawn_anonymous_prover(worker_id: usize, sender: Sender<ProverEvent>) -> JoinHandle<()> {
-    thread::spawn(move || {
-        // Create a new runtime for each thread
-        let rt = Runtime::new().expect("Failed to create Tokio runtime");
-        loop {
-            rt.block_on(async {
-                match prove_anonymously() {
-                    Ok(_) => {
-                        let now = Local::now();
-                        let timestamp = now.format("%Y-%m-%d %H:%M:%S").to_string();
-                        let message = format!(
-                            "✅ [{}] Proof completed successfully [Anonymous Prover {}]",
-                            timestamp, worker_id
-                        );
-                        let _ = sender
-                            .send(ProverEvent::Message {
-                                worker_id,
-                                data: message,
-                            })
-                            .await;
-                    }
-                    Err(e) => {
-                        let message = format!("Anonymous Prover {}: Error - {}", worker_id, e);
-                        let _ = sender
-                            .send(ProverEvent::Message {
-                                worker_id,
-                                data: message,
-                            })
-                            .await;
-                    }
-                }
-            });
-        }
-    })
-}
+/// Spawns a set of worker tasks that receive tasks and send prover events.
+///
+/// # Arguments
+/// * `num_workers` - The number of worker tasks to spawn.
+/// * `prover_event_sender` - The channel to send prover events to the main thread.
+///
+/// # Returns
+/// A tuple containing:
+/// * A vector of `Sender<Task>` for each worker, allowing tasks to be sent to them.
+/// * A vector of `JoinHandle<()>` for each worker, allowing the main thread to await their completion.
+pub fn start_workers(
+    num_workers: usize,
+    prover_event_sender: Sender<ProverEvent>,
+) -> (Vec<Sender<Task>>, Vec<JoinHandle<()>>) {
+    let mut senders = Vec::with_capacity(num_workers);
+    let mut handles = Vec::with_capacity(num_workers);
 
-/// Spawns a new thread for the prover.
-fn spawn_prover(
-    worker_id: usize,
-    mut task_receiver: Receiver<Task>,
-    sender: Sender<ProverEvent>,
-) -> JoinHandle<()> {
-    thread::spawn(move || {
-        let rt = Runtime::new().expect("Failed to create Tokio runtime");
-        rt.block_on(async {
+    for worker_id in 0..num_workers {
+        let (task_sender, mut task_receiver) = tokio::sync::mpsc::channel::<Task>(8);
+        let prover_event_sender = prover_event_sender.clone();
+
+        let handle = tokio::spawn(async move {
             while let Some(task) = task_receiver.recv().await {
                 let stwo_prover =
-                    crate::prover::get_default_stwo_prover().expect("Failed to create Stwo prover");
+                    crate::prover::get_default_stwo_prover().expect("Failed to create prover");
                 match authenticated_proving(task, stwo_prover).await {
                     Ok(_) => {
                         let now = Local::now();
@@ -348,7 +267,7 @@ fn spawn_prover(
                             "✅ [{}] Proof completed successfully [Prover {}]",
                             timestamp, worker_id
                         );
-                        let _ = sender
+                        let _ = prover_event_sender
                             .send(ProverEvent::Message {
                                 worker_id,
                                 data: message,
@@ -357,7 +276,7 @@ fn spawn_prover(
                     }
                     Err(e) => {
                         let message = format!("Worker {}: Error - {}", worker_id, e);
-                        let _ = sender
+                        let _ = prover_event_sender
                             .send(ProverEvent::Message {
                                 worker_id,
                                 data: message,
@@ -367,14 +286,73 @@ fn spawn_prover(
                 }
             }
         });
+
+        senders.push(task_sender);
+        handles.push(handle);
+    }
+
+    (senders, handles)
+}
+
+/// Spawns a dispatcher that forwards tasks to available workers in round-robin fashion.
+pub fn start_dispatcher(
+    mut task_receiver: Receiver<Task>,
+    worker_senders: Vec<Sender<Task>>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut next_worker = 0;
+        while let Some(task) = task_receiver.recv().await {
+            let target = next_worker % worker_senders.len();
+            if (worker_senders[target].send(task).await).is_err() {
+                eprintln!("Dispatcher: worker {} channel closed", target);
+            }
+            next_worker += 1;
+        }
     })
 }
+
+// /// Spawns a new thread for the anonymous prover.
+// fn spawn_anonymous_prover(worker_id: usize, sender: Sender<ProverEvent>) -> JoinHandle<()> {
+//     thread::spawn(move || {
+//         // Create a new runtime for each thread
+//         let rt = Runtime::new().expect("Failed to create Tokio runtime");
+//         loop {
+//             rt.block_on(async {
+//                 match prove_anonymously() {
+//                     Ok(_) => {
+//                         let now = Local::now();
+//                         let timestamp = now.format("%Y-%m-%d %H:%M:%S").to_string();
+//                         let message = format!(
+//                             "✅ [{}] Proof completed successfully [Anonymous Prover {}]",
+//                             timestamp, worker_id
+//                         );
+//                         let _ = sender
+//                             .send(ProverEvent::Message {
+//                                 worker_id,
+//                                 data: message,
+//                             })
+//                             .await;
+//                     }
+//                     Err(e) => {
+//                         let message = format!("Anonymous Prover {}: Error - {}", worker_id, e);
+//                         let _ = sender
+//                             .send(ProverEvent::Message {
+//                                 worker_id,
+//                                 data: message,
+//                             })
+//                             .await;
+//                     }
+//                 }
+//             });
+//         }
+//     })
+// }
 
 #[cfg(test)]
 mod tests {
     use crate::orchestrator::MockOrchestrator;
     use crate::task::Task;
-    use crate::ui::task_master;
+    use crate::ui::fetch_prover_tasks;
     use std::time::Duration;
     use tokio::sync::mpsc;
 
@@ -404,7 +382,7 @@ mod tests {
 
         // Run task_master in a tokio task to stay in the same thread context
         let task_master_handle = tokio::spawn(async move {
-            task_master(node_id, verifying_key, orchestrator_client, task_sender).await;
+            fetch_prover_tasks(node_id, verifying_key, orchestrator_client, task_sender).await;
         });
 
         // Receive tasks

--- a/clients/cli/src/ui/mod.rs
+++ b/clients/cli/src/ui/mod.rs
@@ -4,13 +4,13 @@ mod splash;
 
 use crate::environment::Environment;
 use crate::orchestrator::{Orchestrator, OrchestratorClient};
-use crate::prover_runtime::{start_anonymous_workers, start_authenticated_workers, ProverEvent};
-use crate::ui::dashboard::{render_dashboard, DashboardState};
+use crate::prover_runtime::{ProverEvent, start_anonymous_workers, start_authenticated_workers};
+use crate::ui::dashboard::{DashboardState, render_dashboard};
 use crate::ui::login::render_login;
 use crate::ui::splash::render_splash;
 use crossterm::event::{self, Event, KeyCode};
 use ed25519_dalek::SigningKey;
-use ratatui::{backend::Backend, Frame, Terminal};
+use ratatui::{Frame, Terminal, backend::Backend};
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast;

--- a/clients/cli/src/ui/mod.rs
+++ b/clients/cli/src/ui/mod.rs
@@ -4,13 +4,13 @@ mod splash;
 
 use crate::environment::Environment;
 use crate::orchestrator::{Orchestrator, OrchestratorClient};
-use crate::prover_runtime::{ProverEvent, start_anonymous_workers, start_authenticated_workers};
-use crate::ui::dashboard::{DashboardState, render_dashboard};
+use crate::prover_runtime::{start_anonymous_workers, start_authenticated_workers, ProverEvent};
+use crate::ui::dashboard::{render_dashboard, DashboardState};
 use crate::ui::login::render_login;
 use crate::ui::splash::render_splash;
 use crossterm::event::{self, Event, KeyCode};
 use ed25519_dalek::SigningKey;
-use ratatui::{Frame, Terminal, backend::Backend};
+use ratatui::{backend::Backend, Frame, Terminal};
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
@@ -92,8 +92,8 @@ pub async fn run<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> std::i
     let mut prover_event_receiver = match app.node_id {
         Some(node_id) => start_authenticated_workers(
             node_id,
-            app.signing_key.verifying_key(),
-            Box::new(app.orchestrator_client.clone()),
+            app.signing_key.clone(),
+            app.orchestrator_client.clone(),
             num_workers,
         ),
         None => start_anonymous_workers(num_workers),

--- a/clients/cli/src/ui/mod.rs
+++ b/clients/cli/src/ui/mod.rs
@@ -4,13 +4,13 @@ mod splash;
 
 use crate::environment::Environment;
 use crate::orchestrator::{Orchestrator, OrchestratorClient};
-use crate::prover_runtime::{WorkerEvent, start_anonymous_workers, start_authenticated_workers};
-use crate::ui::dashboard::{DashboardState, render_dashboard};
+use crate::prover_runtime::{start_anonymous_workers, start_authenticated_workers, WorkerEvent};
+use crate::ui::dashboard::{render_dashboard, DashboardState};
 use crate::ui::login::render_login;
 use crate::ui::splash::render_splash;
 use crossterm::event::{self, Event, KeyCode};
 use ed25519_dalek::SigningKey;
-use ratatui::{Frame, Terminal, backend::Backend};
+use ratatui::{backend::Backend, Frame, Terminal};
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
@@ -179,10 +179,9 @@ pub async fn run<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> std::i
                         }
                     }
                     Screen::Login => {
-                        todo!()
-                        // if key.code == KeyCode::Enter {
-                        //     app.login();
-                        // }
+                        if key.code == KeyCode::Enter {
+                            app.login();
+                        }
                     }
                     Screen::Dashboard(_dashboard_state) => {}
                 }

--- a/clients/cli/src/ui/mod.rs
+++ b/clients/cli/src/ui/mod.rs
@@ -10,7 +10,6 @@ use crate::ui::dashboard::{DashboardState, render_dashboard};
 use crate::ui::login::render_login;
 use crate::ui::splash::render_splash;
 use chrono::Local;
-use crossbeam::channel::{bounded, unbounded};
 use crossterm::event::{self, Event, KeyCode};
 use ed25519_dalek::SigningKey;
 use ratatui::{Frame, Terminal, backend::Backend};
@@ -19,8 +18,11 @@ use std::thread;
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 use tokio::runtime::Runtime;
+use tokio::sync::mpsc::{Receiver, Sender, channel};
+use tokio::time::sleep;
 
 /// The different screens in the application.
+#[derive(Debug, Clone)]
 pub enum Screen {
     /// Splash screen shown at the start of the application.
     Splash,
@@ -35,6 +37,7 @@ pub enum Screen {
 const MAX_EVENTS: usize = 100;
 
 /// Application state
+#[derive(Debug, Clone)]
 pub struct App {
     /// The start time of the application, used for computing uptime.
     pub start_time: Instant,
@@ -89,122 +92,154 @@ pub fn run<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> std::io::Res
     let splash_start = Instant::now();
     let splash_duration = Duration::from_secs(2);
 
-    // Spawn a thread for fetching tasks from the orchestrator.
+    // Create a task master that fetches tasks from the orchestrator
     let task_queue_size = 10;
-    let (task_sender, task_receiver) = bounded::<Task>(task_queue_size);
-    let _task_master_handle = {
-        let orchestrator_client = app.orchestrator_client.clone();
-        let sender_clone = task_sender.clone();
-        thread::spawn(move || {
-            task_master(
-                app.node_id.expect("Node ID must be set"),
-                sender_clone,
-                orchestrator_client,
-            )
-        })
-    };
+    let (task_sender, mut task_receiver) = channel::<Task>(task_queue_size);
+    let task_master_handle = tokio::spawn(async move {
+        let orchestrator_client = Box::new(app.orchestrator_client.clone());
+        let node_id = app.node_id.expect("Node ID must be set");
+        task_master(node_id, orchestrator_client, task_sender).await;
+    });
 
-    // Spawn worker threads for background tasks
+    // Create workers
     let num_workers = 1; // TODO: Keep this low for now to avoid hitting rate limits.
-    let mut workers: Vec<JoinHandle<()>> = Vec::with_capacity(num_workers);
-    let (sender, receiver) = unbounded::<ProverEvent>();
+
+    // Channel for sending events from workers to the main thread
+    let (prover_event_sender, mut prover_event_receiver) = channel::<ProverEvent>(100);
+
+    // One channel per worker for sending tasks.
+    let mut worker_senders: Vec<Sender<Task>> = Vec::with_capacity(num_workers);
+
     for worker_id in 0..num_workers {
-        let handle = match app.node_id {
-            Some(node_id) => spawn_prover(
-                worker_id,
-                node_id,
-                app.signing_key.clone(),
-                task_receiver.clone(),
-                sender.clone(),
-            ),
-            None => spawn_anonymous_prover(worker_id, sender.clone()),
-        };
-
-        workers.push(handle);
-    }
-    drop(sender); // Drop original sender to allow receiver to detect end-of-stream.
-    let mut active_workers = num_workers;
-
-    loop {
-        terminal.draw(|f| render(f, &app))?;
-
-        // Handle splash-to-login transition
-        if let Screen::Splash = app.current_screen {
-            if splash_start.elapsed() >= splash_duration {
-                app.current_screen = Screen::Dashboard(DashboardState::new(
-                    app.node_id,
-                    app.environment,
-                    app.start_time,
-                    &app.events,
-                ));
-                continue;
-            }
-        }
-
-        // Poll for key events
-        if event::poll(Duration::from_millis(100))? {
-            if let Event::Key(key) = event::read()? {
-                // Skip events that are not KeyEventKind::Press
-                if key.kind == event::KeyEventKind::Release {
-                    continue;
-                }
-
-                // Handle exit events
-                if matches!(key.code, KeyCode::Esc | KeyCode::Char('q')) {
-                    return Ok(());
-                }
-
-                match &mut app.current_screen {
-                    Screen::Splash => {
-                        // Any key press will skip the splash screen
-                        if key.code != KeyCode::Esc && key.code != KeyCode::Char('q') {
-                            app.current_screen = Screen::Dashboard(DashboardState::new(
-                                app.node_id,
-                                app.environment,
-                                app.start_time,
-                                &app.events,
-                            ));
-                        }
+        let prover_event_sender = prover_event_sender.clone();
+        let (worker_sender, mut worker_receiver) = channel::<Task>(8);
+        worker_senders.push(worker_sender);
+        tokio::spawn(async move {
+            while let Some(task) = worker_receiver.recv().await {
+                // println!("Worker {} processing {:?}", worker_id, task);
+                let stwo_prover =
+                    crate::prover::get_default_stwo_prover().expect("Failed to create Stwo prover");
+                match authenticated_proving(task, stwo_prover).await {
+                    Ok(_) => {
+                        let now = Local::now();
+                        let timestamp = now.format("%Y-%m-%d %H:%M:%S").to_string();
+                        let message = format!(
+                            "✅ [{}] Proof completed successfully [Prover {}]",
+                            timestamp, worker_id
+                        );
+                        let _ = prover_event_sender
+                            .send(ProverEvent::Message {
+                                worker_id,
+                                data: message,
+                            })
+                            .await;
                     }
-                    Screen::Login => {
-                        if key.code == KeyCode::Enter {
-                            app.login();
-                        }
+                    Err(e) => {
+                        let message = format!("Worker {}: Error - {}", worker_id, e);
+                        let _ = prover_event_sender
+                            .send(ProverEvent::Message {
+                                worker_id,
+                                data: message,
+                            })
+                            .await;
                     }
-                    Screen::Dashboard(_dashboard_state) => {}
                 }
             }
-        }
-
-        if active_workers > 0 {
-            while let Ok(event) = receiver.try_recv() {
-                // If Done, decrement active_workers
-                if let ProverEvent::Done {
-                    worker_id: _worker_id,
-                } = &event
-                {
-                    active_workers -= 1;
-                };
-
-                // Add to bounded event buffer
-                if app.events.len() >= MAX_EVENTS {
-                    app.events.pop_front(); // Evict oldest
-                }
-                app.events.push_back(event);
-            }
-        }
+        });
     }
+
+    // Dispatch tasks to workers. This emulates a SPMC (Single Producer, Multiple Consumer) pattern.
+    tokio::spawn(async move {
+        let mut next_worker = 0;
+        while let Some(task) = task_receiver.recv().await {
+            let target = next_worker % worker_senders.len();
+            if let Err(_) = worker_senders[target].send(task).await {
+                eprintln!("Worker {} has closed channel", target);
+            }
+            next_worker += 1;
+        }
+        // println!("Dispatcher exiting");
+    });
+
+    Ok(())
+    // Wait for threads to finish
+
+    // drop(sender); // Drop original sender to allow receiver to detect end-of-stream.
+    // let mut active_workers = num_workers;
+
+    // loop {
+    //     match app.current_screen {
+    //         Screen::Splash => {}
+    //         Screen::Login => {}
+    //         Screen::Dashboard(_) => {
+    //             let state =
+    //                 DashboardState::new(app.node_id, app.environment, app.start_time, &app.events);
+    //             app.current_screen = Screen::Dashboard(state);
+    //         }
+    //     }
+    //     terminal.draw(|f| render(f, &app.current_screen))?;
+    //
+    //     // Handle splash-to-login transition
+    //     if let Screen::Splash = app.current_screen {
+    //         if splash_start.elapsed() >= splash_duration {
+    //             app.current_screen = Screen::Dashboard(DashboardState::new(
+    //                 app.node_id,
+    //                 app.environment,
+    //                 app.start_time,
+    //                 &app.events,
+    //             ));
+    //             continue;
+    //         }
+    //     }
+    //
+    //     // Poll for key events
+    //     if event::poll(Duration::from_millis(100))? {
+    //         if let Event::Key(key) = event::read()? {
+    //             // Skip events that are not KeyEventKind::Press
+    //             if key.kind == event::KeyEventKind::Release {
+    //                 continue;
+    //             }
+    //
+    //             // Handle exit events
+    //             if matches!(key.code, KeyCode::Esc | KeyCode::Char('q')) {
+    //                 // TODO: Close worker threads
+    //                 return Ok(());
+    //             }
+    //
+    //             match &mut app.current_screen {
+    //                 Screen::Splash => {
+    //                     // Any key press will skip the splash screen
+    //                     if key.code != KeyCode::Esc && key.code != KeyCode::Char('q') {
+    //                         app.current_screen = Screen::Dashboard(DashboardState::new(
+    //                             app.node_id,
+    //                             app.environment,
+    //                             app.start_time,
+    //                             &app.events,
+    //                         ));
+    //                     }
+    //                 }
+    //                 Screen::Login => {
+    //                     todo!()
+    //                     // if key.code == KeyCode::Enter {
+    //                     //     app.login();
+    //                     // }
+    //                 }
+    //                 Screen::Dashboard(_dashboard_state) => {}
+    //             }
+    //         }
+    //     }
+    // }
 }
 
 /// Renders the current screen based on the application state.
-fn render(f: &mut Frame, app: &App) {
-    match &app.current_screen {
+fn render(f: &mut Frame, screen: &Screen) {
+    match screen {
         Screen::Splash => render_splash(f),
         Screen::Login => render_login(f),
-        Screen::Dashboard(_state) => {
+        Screen::Dashboard(state) => {
             // Update the dashboard state with the latest events
-            let state =
-                DashboardState::new(app.node_id, app.environment, app.start_time, &app.events);
+            // let state =
+            //     DashboardState::new(app.node_id, app.environment, app.start_time, &app.events);
             render_dashboard(f, &state)
         }
     }
@@ -213,29 +248,28 @@ fn render(f: &mut Frame, app: &App) {
 /// Fetches tasks from the orchestrator and place them in the task queue.
 async fn task_master(
     node_id: u64,
-    sender: crossbeam::channel::Sender<Task>,
-    orchestrator_client: OrchestratorClient,
+    orchestrator_client: Box<dyn Orchestrator>,
+    sender: Sender<Task>,
 ) {
+    println!("Task master started for node ID: {}", node_id);
+
     loop {
-        // If the task queue is empty, fetch new tasks
-        if sender.is_empty() {
-            match orchestrator_client
-                .get_proof_task(&node_id.to_string())
-                .await
-            {
-                Ok(task) => {
-                    if sender.send(task).is_err() {
-                        // If the channel is closed, exit the loop
-                        return;
-                    }
-                }
-                Err(_e) => {
-                    // TODO: log the error
-                    // Wait before retrying to avoid spamming the orchestrator
-                    tokio::time::sleep(Duration::from_secs(2)).await;
+        match orchestrator_client
+            .get_proof_task(&node_id.to_string())
+            .await
+        {
+            Ok(task) => {
+                if sender.send(task).await.is_err() {
+                    println!("sender.send() failed, task queue is closed");
+                    return;
                 }
             }
+            Err(e) => {
+                println!("Failed to fetch task: {}", e);
+            }
         }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
     }
 }
 
@@ -253,10 +287,7 @@ pub enum ProverEvent {
 }
 
 /// Spawns a new thread for the anonymous prover.
-fn spawn_anonymous_prover(
-    worker_id: usize,
-    sender: crossbeam::channel::Sender<ProverEvent>,
-) -> JoinHandle<()> {
+fn spawn_anonymous_prover(worker_id: usize, sender: Sender<ProverEvent>) -> JoinHandle<()> {
     thread::spawn(move || {
         // Create a new runtime for each thread
         let rt = Runtime::new().expect("Failed to create Tokio runtime");
@@ -270,21 +301,21 @@ fn spawn_anonymous_prover(
                             "✅ [{}] Proof completed successfully [Anonymous Prover {}]",
                             timestamp, worker_id
                         );
-                        sender
+                        let _ = sender
                             .send(ProverEvent::Message {
                                 worker_id,
                                 data: message,
                             })
-                            .unwrap();
+                            .await;
                     }
                     Err(e) => {
                         let message = format!("Anonymous Prover {}: Error - {}", worker_id, e);
-                        sender
+                        let _ = sender
                             .send(ProverEvent::Message {
                                 worker_id,
                                 data: message,
                             })
-                            .unwrap();
+                            .await;
                     }
                 }
             });
@@ -295,26 +326,16 @@ fn spawn_anonymous_prover(
 /// Spawns a new thread for the prover.
 fn spawn_prover(
     worker_id: usize,
-    node_id: u64,
-    signing_key: SigningKey,
-    task_receiver: crossbeam::channel::Receiver<Task>,
-    sender: crossbeam::channel::Sender<ProverEvent>,
+    mut task_receiver: Receiver<Task>,
+    sender: Sender<ProverEvent>,
 ) -> JoinHandle<()> {
     thread::spawn(move || {
-        // Create a new runtime for each thread
         let rt = Runtime::new().expect("Failed to create Tokio runtime");
-        loop {
-            rt.block_on(async {
+        rt.block_on(async {
+            while let Some(task) = task_receiver.recv().await {
                 let stwo_prover =
                     crate::prover::get_default_stwo_prover().expect("Failed to create Stwo prover");
-                match authenticated_proving(
-                    node_id,
-                    task_receiver.clone(),
-                    stwo_prover,
-                    signing_key.clone(),
-                )
-                .await
-                {
+                match authenticated_proving(task, stwo_prover).await {
                     Ok(_) => {
                         let now = Local::now();
                         let timestamp = now.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -322,24 +343,91 @@ fn spawn_prover(
                             "✅ [{}] Proof completed successfully [Prover {}]",
                             timestamp, worker_id
                         );
-                        sender
+                        let _ = sender
                             .send(ProverEvent::Message {
                                 worker_id,
                                 data: message,
                             })
-                            .unwrap();
+                            .await;
                     }
                     Err(e) => {
                         let message = format!("Worker {}: Error - {}", worker_id, e);
-                        sender
+                        let _ = sender
                             .send(ProverEvent::Message {
                                 worker_id,
                                 data: message,
                             })
-                            .unwrap();
+                            .await;
                     }
                 }
-            });
-        }
+            }
+        });
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::orchestrator::MockOrchestrator;
+    use crate::task::Task;
+    use crate::ui::task_master;
+    use std::time::Duration;
+    use tokio::sync::mpsc;
+
+    /// Creates a mock orchestrator client that simulates fetching tasks.
+    fn get_mock_orchestrator_client(num_task_requests: usize) -> MockOrchestrator {
+        let tasks = (0..num_task_requests)
+            .map(|i| Task::new(i.to_string(), format!("Task {}", i), vec![1, 2, 3]))
+            .collect::<Vec<_>>();
+
+        let mut call_index = 0;
+
+        let mut mock = MockOrchestrator::new();
+        mock.expect_get_proof_task()
+            .times(num_task_requests)
+            .returning_st(move |_| {
+                println!("Mock get_proof_task called with index {}", call_index);
+                // Simulate a task with dummy data
+                // let task = Task::new("1".to_string(), "Test Task".to_string(), vec![1, 2, 3]);
+                let task = tasks[call_index].clone();
+                call_index += 1;
+                Ok(task)
+            });
+        mock
+    }
+
+    #[tokio::test]
+    // The task master should fetch and enqueue tasks from the orchestrator.
+    async fn test_task_master() {
+        let orchestrator_client = Box::new(get_mock_orchestrator_client(10));
+        let node_id = 1003;
+
+        let task_queue_size = 10;
+        let (task_sender, mut task_receiver) = mpsc::channel::<Task>(task_queue_size);
+
+        // Run task_master in a tokio task to stay in the same thread context
+        let task_handle = tokio::spawn(async move {
+            task_master(node_id, orchestrator_client, task_sender).await;
+        });
+
+        // Receive tasks
+        let mut received = 0;
+        for i in 0..task_queue_size {
+            match tokio::time::timeout(Duration::from_secs(2), task_receiver.recv()).await {
+                Ok(Some(task)) => {
+                    println!("Received task {}: {:?}", received, task);
+                    received += 1;
+                }
+                Ok(None) => {
+                    eprintln!("Channel closed unexpectedly");
+                    break;
+                }
+                Err(_) => {
+                    eprintln!("Timed out waiting for task {}", received);
+                    break;
+                }
+            }
+        }
+
+        task_handle.await.unwrap();
+    }
 }

--- a/clients/cli/src/ui/mod.rs
+++ b/clients/cli/src/ui/mod.rs
@@ -4,13 +4,13 @@ mod splash;
 
 use crate::environment::Environment;
 use crate::orchestrator::{Orchestrator, OrchestratorClient};
-use crate::prover_runtime::{start_anonymous_workers, start_authenticated_workers, ProverEvent};
-use crate::ui::dashboard::{render_dashboard, DashboardState};
+use crate::prover_runtime::{ProverEvent, start_anonymous_workers, start_authenticated_workers};
+use crate::ui::dashboard::{DashboardState, render_dashboard};
 use crate::ui::login::render_login;
 use crate::ui::splash::render_splash;
 use crossterm::event::{self, Event, KeyCode};
 use ed25519_dalek::SigningKey;
-use ratatui::{backend::Backend, Frame, Terminal};
+use ratatui::{Frame, Terminal, backend::Backend};
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 

--- a/clients/cli/src/ui/mod.rs
+++ b/clients/cli/src/ui/mod.rs
@@ -4,19 +4,15 @@ mod splash;
 
 use crate::environment::Environment;
 use crate::orchestrator::{Orchestrator, OrchestratorClient};
-use crate::prover::authenticated_proving;
-use crate::task::Task;
+use crate::prover_runtime::{ProverEvent, start_anonymous_workers, start_authenticated_workers};
 use crate::ui::dashboard::{DashboardState, render_dashboard};
 use crate::ui::login::render_login;
 use crate::ui::splash::render_splash;
-use chrono::Local;
 use crossterm::event::{self, Event, KeyCode};
-use ed25519_dalek::{SigningKey, VerifyingKey};
+use ed25519_dalek::SigningKey;
 use ratatui::{Frame, Terminal, backend::Backend};
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
-use tokio::sync::mpsc::{Receiver, Sender, channel};
-use tokio::task::JoinHandle;
 
 /// The different screens in the application.
 #[derive(Debug, Clone)]
@@ -90,27 +86,18 @@ pub async fn run<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> std::i
     let splash_start = Instant::now();
     let splash_duration = Duration::from_secs(2);
 
-    // TODO: prove anonymously if node_id is None
+    let num_workers = 2; // TODO: Keep this low for now to avoid hitting rate limits.
 
-    // Create a task master that fetches tasks from the orchestrator
-    let task_queue_size = 10;
-    let (task_sender, task_receiver) = channel::<Task>(task_queue_size);
-    let verifying_key = app.signing_key.verifying_key();
-
-    // Spawn a Tokio task to fetch proving tasks from the orchestrator.
-    let _fetch_prover_tasks_handle = tokio::spawn(async move {
-        let orchestrator_client = Box::new(app.orchestrator_client.clone());
-        let node_id = app.node_id.expect("Node ID must be set");
-        fetch_prover_tasks(node_id, verifying_key, orchestrator_client, task_sender).await;
-    });
-
-    // Channel for sending events from workers to the main thread
-    let (prover_event_sender, mut prover_event_receiver) = channel::<ProverEvent>(100);
-    let num_workers = 3; // TODO: Keep this low for now to avoid hitting rate limits.
-    let (worker_senders, _worker_handles) = start_workers(num_workers, prover_event_sender.clone());
-
-    // Dispatch tasks to workers. This emulates a SPMC (Single Producer, Multiple Consumer) pattern.
-    let _dispatcher_handle = start_dispatcher(task_receiver, worker_senders);
+    // Receives events from prover worker threads.
+    let mut prover_event_receiver = match app.node_id {
+        Some(node_id) => start_authenticated_workers(
+            node_id,
+            app.signing_key.verifying_key(),
+            Box::new(app.orchestrator_client.clone()),
+            num_workers,
+        ),
+        None => start_anonymous_workers(num_workers),
+    };
 
     // UI event loop
     loop {
@@ -122,6 +109,7 @@ pub async fn run<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> std::i
             app.events.push_back(event);
         }
 
+        // Update the state based on the current screen
         match app.current_screen {
             Screen::Splash => {}
             Screen::Login => {}
@@ -191,219 +179,5 @@ fn render(f: &mut Frame, screen: &Screen) {
         Screen::Splash => render_splash(f),
         Screen::Login => render_login(f),
         Screen::Dashboard(state) => render_dashboard(f, state),
-    }
-}
-
-/// Fetches tasks from the orchestrator and place them in the task queue.
-async fn fetch_prover_tasks(
-    node_id: u64,
-    verifying_key: VerifyingKey,
-    orchestrator_client: Box<dyn Orchestrator>,
-    sender: Sender<Task>,
-) {
-    loop {
-        match orchestrator_client
-            .get_proof_task(&node_id.to_string(), verifying_key)
-            .await
-        {
-            Ok(task) => {
-                if sender.send(task).await.is_err() {
-                    println!("sender.send() failed, task queue is closed");
-                    return;
-                }
-            }
-            Err(e) => {
-                println!("Failed to fetch task: {}", e);
-            }
-        }
-        // Be polite to the orchestrator and wait a bit before fetching the next task.
-        tokio::time::sleep(Duration::from_millis(200)).await;
-    }
-}
-
-/// Events emitted by prover (worker) threads.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub enum ProverEvent {
-    Message {
-        worker_id: usize,
-        data: String,
-    },
-    #[allow(unused)]
-    Done {
-        worker_id: usize,
-    },
-}
-
-/// Spawns a set of worker tasks that receive tasks and send prover events.
-///
-/// # Arguments
-/// * `num_workers` - The number of worker tasks to spawn.
-/// * `prover_event_sender` - The channel to send prover events to the main thread.
-///
-/// # Returns
-/// A tuple containing:
-/// * A vector of `Sender<Task>` for each worker, allowing tasks to be sent to them.
-/// * A vector of `JoinHandle<()>` for each worker, allowing the main thread to await their completion.
-pub fn start_workers(
-    num_workers: usize,
-    prover_event_sender: Sender<ProverEvent>,
-) -> (Vec<Sender<Task>>, Vec<JoinHandle<()>>) {
-    let mut senders = Vec::with_capacity(num_workers);
-    let mut handles = Vec::with_capacity(num_workers);
-
-    for worker_id in 0..num_workers {
-        let (task_sender, mut task_receiver) = tokio::sync::mpsc::channel::<Task>(8);
-        let prover_event_sender = prover_event_sender.clone();
-
-        let handle = tokio::spawn(async move {
-            while let Some(task) = task_receiver.recv().await {
-                let stwo_prover =
-                    crate::prover::get_default_stwo_prover().expect("Failed to create prover");
-                match authenticated_proving(task, stwo_prover).await {
-                    Ok(_) => {
-                        let now = Local::now();
-                        let timestamp = now.format("%Y-%m-%d %H:%M:%S").to_string();
-                        let message = format!(
-                            "✅ [{}] Proof completed successfully [Prover {}]",
-                            timestamp, worker_id
-                        );
-                        let _ = prover_event_sender
-                            .send(ProverEvent::Message {
-                                worker_id,
-                                data: message,
-                            })
-                            .await;
-                    }
-                    Err(e) => {
-                        let message = format!("Worker {}: Error - {}", worker_id, e);
-                        let _ = prover_event_sender
-                            .send(ProverEvent::Message {
-                                worker_id,
-                                data: message,
-                            })
-                            .await;
-                    }
-                }
-            }
-        });
-
-        senders.push(task_sender);
-        handles.push(handle);
-    }
-
-    (senders, handles)
-}
-
-/// Spawns a dispatcher that forwards tasks to available workers in round-robin fashion.
-pub fn start_dispatcher(
-    mut task_receiver: Receiver<Task>,
-    worker_senders: Vec<Sender<Task>>,
-) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        let mut next_worker = 0;
-        while let Some(task) = task_receiver.recv().await {
-            let target = next_worker % worker_senders.len();
-            if (worker_senders[target].send(task).await).is_err() {
-                eprintln!("Dispatcher: worker {} channel closed", target);
-            }
-            next_worker += 1;
-        }
-    })
-}
-
-// /// Spawns a new thread for the anonymous prover.
-// fn spawn_anonymous_prover(worker_id: usize, sender: Sender<ProverEvent>) -> JoinHandle<()> {
-//     thread::spawn(move || {
-//         // Create a new runtime for each thread
-//         let rt = Runtime::new().expect("Failed to create Tokio runtime");
-//         loop {
-//             rt.block_on(async {
-//                 match prove_anonymously() {
-//                     Ok(_) => {
-//                         let now = Local::now();
-//                         let timestamp = now.format("%Y-%m-%d %H:%M:%S").to_string();
-//                         let message = format!(
-//                             "✅ [{}] Proof completed successfully [Anonymous Prover {}]",
-//                             timestamp, worker_id
-//                         );
-//                         let _ = sender
-//                             .send(ProverEvent::Message {
-//                                 worker_id,
-//                                 data: message,
-//                             })
-//                             .await;
-//                     }
-//                     Err(e) => {
-//                         let message = format!("Anonymous Prover {}: Error - {}", worker_id, e);
-//                         let _ = sender
-//                             .send(ProverEvent::Message {
-//                                 worker_id,
-//                                 data: message,
-//                             })
-//                             .await;
-//                     }
-//                 }
-//             });
-//         }
-//     })
-// }
-
-#[cfg(test)]
-mod tests {
-    use crate::orchestrator::MockOrchestrator;
-    use crate::task::Task;
-    use crate::ui::fetch_prover_tasks;
-    use std::time::Duration;
-    use tokio::sync::mpsc;
-
-    /// Creates a mock orchestrator client that simulates fetching tasks.
-    fn get_mock_orchestrator_client() -> MockOrchestrator {
-        let mut i = 0;
-        let mut mock = MockOrchestrator::new();
-        mock.expect_get_proof_task().returning_st(move |_, _| {
-            // Simulate a task with dummy data
-            let task = Task::new(i.to_string(), format!("Task {}", i), vec![1, 2, 3]);
-            i += 1;
-            Ok(task)
-        });
-        mock
-    }
-
-    #[tokio::test]
-    // The task master should fetch and enqueue tasks from the orchestrator.
-    async fn test_task_master() {
-        let orchestrator_client = Box::new(get_mock_orchestrator_client());
-        let signer_key = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
-        let verifying_key = signer_key.verifying_key();
-        let node_id = 1234;
-
-        let task_queue_size = 10;
-        let (task_sender, mut task_receiver) = mpsc::channel::<Task>(task_queue_size);
-
-        // Run task_master in a tokio task to stay in the same thread context
-        let task_master_handle = tokio::spawn(async move {
-            fetch_prover_tasks(node_id, verifying_key, orchestrator_client, task_sender).await;
-        });
-
-        // Receive tasks
-        let mut received = 0;
-        for _i in 0..task_queue_size {
-            match tokio::time::timeout(Duration::from_secs(2), task_receiver.recv()).await {
-                Ok(Some(task)) => {
-                    println!("Received task {}: {:?}", received, task);
-                    received += 1;
-                }
-                Ok(None) => {
-                    eprintln!("Channel closed unexpectedly");
-                    break;
-                }
-                Err(_) => {
-                    eprintln!("Timed out waiting for task {}", received);
-                    break;
-                }
-            }
-        }
-
-        task_master_handle.abort();
     }
 }


### PR DESCRIPTION
Previously, each worker thread queried the Orchestrator directly for new tasks, leading to "429 Too many requests" errors.

This introduces a single background task that queries the Orchestrator and enqueues tasks for the provers. This task uses the newer API to request existing tasks, and requests that new tasks be assigned as needed.

Fixes: https://linear.app/nexus-labs/issue/NET-1266/cli-efficiently-manage-cli-orchestrator-messages
Fixes: https://linear.app/nexus-labs/issue/NET-1239/cli-prover-threads-should-consume-from-a-task-queue

TODO
- [x] Query orchestrator in background task
- [x] Prover threads consume from task queue
- [x] Query for batches of existing tasks (helps resolve "429 Too many requests" issues)
- [x] Submit completed proof tasks 
- [x] Gracefully shut down threads on app exit
- [x] Supports anonymous proving
- [x] Network events, error events in UI Logs  

<img width="1414" alt="Screenshot 2025-06-12 at 11 43 56 AM" src="https://github.com/user-attachments/assets/b433b73a-0c5d-40ab-8223-0edac941c7f2" />
