### PR TITLE
feat: Adds "--headless" flag to Start command for running without the Terminal UI

### DIFF
--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -1647,6 +1647,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
+ "strum",
  "sysinfo",
  "tempfile",
  "thiserror 2.0.12",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -49,6 +49,7 @@ tokio = { version = "1.38", features = ["full"] }
 uuid = "1.16.0"
 async-trait = "0.1.88"
 prost-types = "0.13.5"
+strum = "0.26.3"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -13,18 +13,20 @@ pub mod system;
 mod task;
 mod ui;
 
-use crate::config::{Config, get_config_path};
+use crate::config::{get_config_path, Config};
 use crate::environment::Environment;
 use crate::orchestrator::{Orchestrator, OrchestratorClient};
-use clap::{Parser, Subcommand};
+use crate::prover_runtime::{start_anonymous_workers, start_authenticated_workers};
+use clap::{ArgAction, Parser, Subcommand};
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},
     execute,
-    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ed25519_dalek::SigningKey;
-use ratatui::{Terminal, backend::CrosstermBackend};
+use ratatui::{backend::CrosstermBackend, Terminal};
 use std::{error::Error, io};
+use tokio::sync::broadcast;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -43,8 +45,12 @@ enum Command {
         #[arg(long, value_name = "NODE_ID")]
         node_id: Option<u64>,
 
+        /// Run without the terminal UI
+        #[arg(long = "headless", action = ArgAction::SetTrue)]
+        headless: bool,
+
         /// Maximum number of threads to use for proving.
-        #[arg(long)]
+        #[arg(long = "max-threads", value_name = "MAX_THREADS")]
         max_threads: Option<u32>,
     },
     /// Register a new user
@@ -75,6 +81,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     match args.command {
         Command::Start {
             node_id,
+            headless,
             max_threads,
         } => {
             let mut node_id = node_id;
@@ -86,7 +93,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     }
                 }
             }
-            start(node_id, environment, max_threads).await
+            start(node_id, environment, headless, max_threads).await
         }
         Command::Logout => {
             println!("Logging out and clearing node configuration file...");
@@ -188,36 +195,75 @@ async fn main() -> Result<(), Box<dyn Error>> {
 async fn start(
     node_id: Option<u64>,
     env: Environment,
+    headless: bool,
     _max_threads: Option<u32>,
 ) -> Result<(), Box<dyn Error>> {
-    // Terminal setup
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-
-    // Initialize the terminal with Crossterm backend.
-    let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
-
-    // Create the application and run it.
-    let orchestrator_client = OrchestratorClient::new(env);
     // TODO: Persist the signing key in the config file.
     let mut csprng = rand_core::OsRng;
     let signing_key: SigningKey = SigningKey::generate(&mut csprng);
-    let app = ui::App::new(node_id, orchestrator_client, signing_key);
-    let res = ui::run(&mut terminal, app) // this call must now be `async fn run()`
-        .await;
 
-    // Clean up the terminal after running the application.
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
+    let orchestrator_client = OrchestratorClient::new(env);
 
-    res?;
-    println!("Nexus CLI application exited successfully.");
+    let num_workers = 3; // TODO: Keep this low for now to avoid hitting rate limits.
+    let (shutdown_sender, _) = broadcast::channel(1); // Only one shutdown signal needed
+    let (mut event_receiver, mut join_handles) = match node_id {
+        Some(node_id) => {
+            start_authenticated_workers(
+                node_id,
+                signing_key.clone(),
+                orchestrator_client.clone(),
+                num_workers,
+                shutdown_sender.subscribe(),
+            )
+            .await
+        }
+        None => start_anonymous_workers(num_workers, shutdown_sender.subscribe()).await,
+    };
+
+    if !headless {
+        // Terminal setup
+        enable_raw_mode()?;
+        let mut stdout = io::stdout();
+        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+
+        // Initialize the terminal with Crossterm backend.
+        let backend = CrosstermBackend::new(stdout);
+        let mut terminal = Terminal::new(backend)?;
+
+        // Create the application and run it.
+        let app = ui::App::new(
+            node_id,
+            *orchestrator_client.environment(),
+            event_receiver,
+            shutdown_sender,
+        );
+        let res = ui::run(&mut terminal, app) // this call must now be `async fn run()`
+            .await;
+
+        // Clean up the terminal after running the application.
+        disable_raw_mode()?;
+        execute!(
+            terminal.backend_mut(),
+            LeaveAlternateScreen,
+            DisableMouseCapture
+        )?;
+        terminal.show_cursor()?;
+
+        res?;
+
+        println!("Exiting...");
+        for handle in join_handles.drain(..) {
+            let _ = handle.await;
+        }
+        println!("Nexus CLI application exited successfully.");
+    } else {
+        // Print events to stdout in a loop
+        loop {
+            // Drain prover events from the async channel into app.events
+            while let Ok(event) = event_receiver.try_recv() {
+                println!("{}", event);
+            }
+        }
+    }
     Ok(())
 }

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -198,12 +198,10 @@ async fn start(
     headless: bool,
     _max_threads: Option<u32>,
 ) -> Result<(), Box<dyn Error>> {
-    // TODO: Persist the signing key in the config file.
+    // Create a signing key for the prover.
     let mut csprng = rand_core::OsRng;
     let signing_key: SigningKey = SigningKey::generate(&mut csprng);
-
     let orchestrator_client = OrchestratorClient::new(env);
-
     let num_workers = 3; // TODO: Keep this low for now to avoid hitting rate limits.
     let (shutdown_sender, _) = broadcast::channel(1); // Only one shutdown signal needed
     let (mut event_receiver, mut join_handles) = match node_id {
@@ -237,8 +235,7 @@ async fn start(
             event_receiver,
             shutdown_sender,
         );
-        let res = ui::run(&mut terminal, app) // this call must now be `async fn run()`
-            .await;
+        let res = ui::run(&mut terminal, app).await;
 
         // Clean up the terminal after running the application.
         disable_raw_mode()?;

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -13,7 +13,7 @@ pub mod system;
 mod task;
 mod ui;
 
-use crate::config::{get_config_path, Config};
+use crate::config::{Config, get_config_path};
 use crate::environment::Environment;
 use crate::orchestrator::{Orchestrator, OrchestratorClient};
 use crate::prover_runtime::{start_anonymous_workers, start_authenticated_workers};
@@ -21,10 +21,10 @@ use clap::{ArgAction, Parser, Subcommand};
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},
     execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use ed25519_dalek::SigningKey;
-use ratatui::{backend::CrosstermBackend, Terminal};
+use ratatui::{Terminal, backend::CrosstermBackend};
 use std::{error::Error, io};
 use tokio::sync::broadcast;
 

--- a/clients/cli/src/prover_runtime.rs
+++ b/clients/cli/src/prover_runtime.rs
@@ -16,17 +16,73 @@ use chrono::Local;
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use nexus_sdk::stwo::seq::Proof;
 use sha3::{Digest, Keccak256};
+use std::fmt::Display;
+use std::string::ToString;
 use std::time::Duration;
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinHandle;
 
-/// Events emitted by prover (worker) threads.
-#[allow(unused)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Worker {
+    /// Worker that fetches tasks from the orchestrator and processes them.
+    TaskFetcher,
+    /// Worker that performs proving tasks.
+    Prover(usize),
+    /// Worker that submits proofs to the orchestrator.
+    ProofSubmitter,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, strum::Display)]
+pub enum EventType {
+    Success,
+    Error,
+    Refresh,
+    Shutdown,
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum WorkerEvent {
-    TaskFetcher { data: String },
-    Prover { worker_id: usize, data: String },
-    ProofSubmitter { data: String },
+pub struct Event {
+    pub worker: Worker,
+    pub msg: String,
+    pub timestamp: String,
+    pub event_type: EventType,
+}
+impl Event {
+    pub fn new(kind: Worker, msg: String, event_type: EventType) -> Self {
+        Self {
+            worker: kind,
+            msg,
+            timestamp: Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
+            event_type,
+        }
+    }
+
+    pub fn task_fetcher(msg: String, event_type: EventType) -> Self {
+        Self::new(Worker::TaskFetcher, msg, event_type)
+    }
+
+    pub fn prover(worker_id: usize, msg: String, event_type: EventType) -> Self {
+        Self::new(Worker::Prover(worker_id), msg, event_type)
+    }
+
+    pub fn proof_submitter(msg: String, event_type: EventType) -> Self {
+        Self::new(Worker::ProofSubmitter, msg, event_type)
+    }
+}
+
+impl Display for Event {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let worker_type: String = match self.worker {
+            Worker::TaskFetcher => "Task Fetcher".to_string(),
+            Worker::Prover(worker_id) => format!("Prover {}", worker_id),
+            Worker::ProofSubmitter => "Proof Submitter".to_string(),
+        };
+        write!(
+            f,
+            "{} [{}] {}: {}",
+            self.event_type, self.timestamp, worker_type, self.msg
+        )
+    }
 }
 
 // Queue sizes. Chosen to be larger than the tasks API page size (currently, 50)
@@ -41,10 +97,10 @@ pub async fn start_authenticated_workers(
     orchestrator: OrchestratorClient,
     num_workers: usize,
     shutdown: broadcast::Receiver<()>,
-) -> (mpsc::Receiver<WorkerEvent>, Vec<JoinHandle<()>>) {
+) -> (mpsc::Receiver<Event>, Vec<JoinHandle<()>>) {
     let mut join_handles = Vec::new();
     // Worker events
-    let (event_sender, event_receiver) = mpsc::channel::<WorkerEvent>(EVENT_QUEUE_SIZE);
+    let (event_sender, event_receiver) = mpsc::channel::<Event>(EVENT_QUEUE_SIZE);
 
     // Task fetching
     let (task_sender, task_receiver) = mpsc::channel::<Task>(TASK_QUEUE_SIZE);
@@ -100,11 +156,11 @@ pub async fn start_authenticated_workers(
 pub async fn start_anonymous_workers(
     num_workers: usize,
     shutdown: broadcast::Receiver<()>,
-) -> (mpsc::Receiver<WorkerEvent>, Vec<JoinHandle<()>>) {
-    let (prover_event_sender, prover_event_receiver) = mpsc::channel::<WorkerEvent>(100);
+) -> (mpsc::Receiver<Event>, Vec<JoinHandle<()>>) {
+    let (event_sender, event_receiver) = mpsc::channel::<Event>(100);
     let mut join_handles = Vec::new();
     for worker_id in 0..num_workers {
-        let prover_event_sender = prover_event_sender.clone();
+        let prover_event_sender = event_sender.clone();
         let mut shutdown_rx = shutdown.resubscribe(); // clone receiver for each worker
 
         let handle = tokio::spawn(async move {
@@ -113,10 +169,7 @@ pub async fn start_anonymous_workers(
                     _ = shutdown_rx.recv() => {
                         let message = format!("Worker {} received shutdown signal", worker_id);
                         let _ = prover_event_sender
-                            .send(WorkerEvent::Prover {
-                                worker_id,
-                                data: message,
-                            })
+                            .send(Event::prover(worker_id, message, EventType::Shutdown))
                             .await;
                         break; // Exit the loop on shutdown signal
                     }
@@ -125,23 +178,13 @@ pub async fn start_anonymous_workers(
                         // Perform work
                         match crate::prover::prove_anonymously() {
                             Ok(_proof) => {
-                                let now = Local::now();
-                                let timestamp = now.format("%Y-%m-%d %H:%M:%S").to_string();
-                                let message = format!(
-                                    "✅ [{}] Anonymous proof completed successfully (Prover {})",
-                                    timestamp, worker_id
-                                );
-                                let _ = prover_event_sender.send(WorkerEvent::Prover {
-                                    worker_id,
-                                    data: message,
-                                }).await;
+                                let message = "Anonymous proof completed successfully".to_string();
+                                let _ = prover_event_sender
+                                    .send(Event::prover(worker_id, message, EventType::Success)).await;
                             }
                             Err(e) => {
-                                let message = format!("Anonymous Worker {}: Error - {}", worker_id, e);
-                                let _ = prover_event_sender.send(WorkerEvent::Prover {
-                                    worker_id,
-                                    data: message,
-                                }).await;
+                                let message = format!("Anonymous Worker: Error - {}", e);
+                                let _ =  prover_event_sender.send(Event::prover(worker_id, message, EventType::Error)).await;
                             }
                         }
                     }
@@ -151,7 +194,7 @@ pub async fn start_anonymous_workers(
         join_handles.push(handle);
     }
 
-    (prover_event_receiver, join_handles)
+    (event_receiver, join_handles)
 }
 
 /// Fetches tasks from the orchestrator and place them in the task queue.
@@ -160,7 +203,7 @@ pub async fn fetch_prover_tasks(
     verifying_key: VerifyingKey,
     orchestrator_client: Box<dyn Orchestrator>,
     sender: mpsc::Sender<Task>,
-    event_sender: mpsc::Sender<WorkerEvent>,
+    event_sender: mpsc::Sender<Event>,
     mut shutdown: broadcast::Receiver<()>,
 ) {
     let mut fetch_existing_tasks = true;
@@ -172,27 +215,27 @@ pub async fn fetch_prover_tasks(
             _ = tokio::time::sleep(Duration::from_millis(100)) => {
                 // Get existing tasks.
                 if fetch_existing_tasks {
-                    let now = Local::now();
-                    let timestamp = now.format("%Y-%m-%d %H:%M:%S").to_string();
                     match orchestrator_client.get_tasks(&node_id.to_string()).await {
                         Ok(tasks) => {
-                            let msg = format!("🔄 [{}] Fetched {} tasks", timestamp, tasks.len());
+                            // 🔄
+                            let msg = format!("Fetched {} tasks", tasks.len());
                             let _ = event_sender
-                                        .send(WorkerEvent::TaskFetcher { data: msg })
+                                        .send(Event::task_fetcher(msg, EventType::Refresh))
                                         .await;
                             for task in tasks {
                                 if sender.send(task).await.is_err() {
                                     let _ = event_sender
-                                        .send(WorkerEvent::TaskFetcher { data: "Task queue is closed".to_string() })
+                                        .send(Event::task_fetcher("Task queue is closed".to_string(), EventType::Shutdown))
                                         .await;
                                 }
                             }
                             fetch_existing_tasks = false;
                         }
                         Err(e) => {
-                            let message = format!("⚠️ [{}] Failed to fetch existing tasks: {}", timestamp, e);
+                            // ⚠️
+                            let msg = format!("Failed to fetch existing tasks: {}", e);
                             let _ = event_sender
-                                .send(WorkerEvent::TaskFetcher { data: message })
+                                .send(Event::task_fetcher(msg, EventType::Error))
                                 .await;
                         }
                     }
@@ -204,7 +247,7 @@ pub async fn fetch_prover_tasks(
                     Ok(task) => {
                         if sender.send(task).await.is_err() {
                             let _ = event_sender
-                                .send(WorkerEvent::TaskFetcher { data: "Task queue is closed".to_string() })
+                                .send(Event::task_fetcher("Task queue is closed".to_string(), EventType::Shutdown))
                                 .await;
                         }
                     }
@@ -227,7 +270,7 @@ pub async fn submit_proofs(
     signing_key: SigningKey,
     orchestrator: Box<dyn Orchestrator>,
     mut results: mpsc::Receiver<(Task, Proof)>,
-    event_sender: mpsc::Sender<WorkerEvent>,
+    event_sender: mpsc::Sender<Event>,
     mut shutdown: broadcast::Receiver<()>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -239,42 +282,40 @@ pub async fn submit_proofs(
                             let proof_bytes = postcard::to_allocvec(&proof)
                                 .expect("Failed to serialize proof");
                             let proof_hash = format!("{:x}", Keccak256::digest(&proof_bytes));
-                            let now = Local::now();
-                            let timestamp = now.format("%Y-%m-%d %H:%M:%S").to_string();
+                            // let now = Local::now();
+                            // let timestamp = now.format("%Y-%m-%d %H:%M:%S").to_string();
                             match orchestrator
                                 .submit_proof(&task.task_id, &proof_hash, proof_bytes, signing_key.clone())
                                 .await
                             {
                                 Ok(_) => {
+                                    // ✅
                                     let msg = format!(
-                                        "✅ [{}] Successfully submitted proof for task {}",
-                                        timestamp,
+                                        "Successfully submitted proof for task {}",
                                         task.task_id
                                     );
                                     let _ = event_sender
-                                        .send(WorkerEvent::ProofSubmitter { data: msg })
+                                        .send(Event::proof_submitter(msg, EventType::Success))
                                         .await;
                             }
                                 Err(OrchestratorError::Http {status, message: _message}) => {
                                     let msg = format!(
-                                        "⚠️ [{}] Failed to submit proof for task {}. Status: {}",
-                                        timestamp,
+                                        "Failed to submit proof for task {}. Status: {}",
                                         task.task_id,
                                         status,
                                     );
                                     let _ = event_sender
-                                        .send(WorkerEvent::ProofSubmitter { data: msg })
+                                        .send(Event::proof_submitter(msg, EventType::Error))
                                         .await;
                                 }
                                 Err(e) => {
                                     let msg = format!(
-                                        "⚠️ [{}] Failed to submit proof for task {}: {}",
-                                        timestamp,
+                                        "Failed to submit proof for task {}: {}",
                                         task.task_id,
                                         e
                                     );
                                     let _ = event_sender
-                                        .send(WorkerEvent::ProofSubmitter { data: msg })
+                                        .send(Event::proof_submitter(msg, EventType::Error))
                                         .await;
                                 }
                             }
@@ -334,7 +375,7 @@ pub fn start_dispatcher(
 pub fn start_workers(
     num_workers: usize,
     results_sender: mpsc::Sender<(Task, Proof)>,
-    event_sender: mpsc::Sender<WorkerEvent>,
+    event_sender: mpsc::Sender<Event>,
     shutdown: broadcast::Receiver<()>,
 ) -> (Vec<mpsc::Sender<Task>>, Vec<JoinHandle<()>>) {
     let mut senders = Vec::with_capacity(num_workers);
@@ -352,39 +393,27 @@ pub fn start_workers(
                     _ = shutdown.recv() => {
                         let message = format!("Worker {} received shutdown signal", worker_id);
                         let _ = prover_event_sender
-                            .send(WorkerEvent::Prover {
-                                worker_id,
-                                data: message,
-                            })
+                            .send(Event::prover(worker_id, message, EventType::Shutdown))
                             .await;
                         break; // Exit the loop on shutdown signal
                     }
                     _ = tokio::time::sleep(Duration::from_millis(100)) => {
-                        // Continue processing the task
-                        let now = Local::now();
-                        let timestamp = now.format("%Y-%m-%d %H:%M:%S").to_string();
                         match authenticated_proving(&task).await {
                             Ok(proof) => {
                                 let message = format!(
-                                    "✅ [{}] Proof completed successfully (Prover {})",
-                                    timestamp, worker_id
+                                    "Proof completed successfully (Prover {})",
+                                    worker_id
                                 );
                                 let _ = prover_event_sender
-                                    .send(WorkerEvent::Prover {
-                                        worker_id,
-                                        data: message,
-                                    })
+                                    .send(Event::prover(worker_id, message, EventType::Success))
                                     .await;
 
                                 let _ = results_sender.send((task, proof)).await; // Send the task and proof to the results channel
                             }
                             Err(e) => {
-                                let message = format!("⚠️ [{}] Error - {}", timestamp, e);
+                                let message = format!("Error: {}", e);
                                 let _ = prover_event_sender
-                                    .send(WorkerEvent::Prover {
-                                        worker_id,
-                                        data: message,
-                                    })
+                                    .send(Event::prover(worker_id, message, EventType::Error))
                                     .await;
                             }
                         }
@@ -403,7 +432,7 @@ pub fn start_workers(
 #[cfg(test)]
 mod tests {
     use crate::orchestrator::MockOrchestrator;
-    use crate::prover_runtime::{WorkerEvent, fetch_prover_tasks};
+    use crate::prover_runtime::{fetch_prover_tasks, Event};
     use crate::task::Task;
     use std::time::Duration;
     use tokio::sync::{broadcast, mpsc};
@@ -434,7 +463,7 @@ mod tests {
 
         // Run task_master in a tokio task to stay in the same thread context
         let (shutdown_sender, _) = broadcast::channel(1); // Only one shutdown signal needed
-        let (event_sender, _event_receiver) = mpsc::channel::<WorkerEvent>(100);
+        let (event_sender, _event_receiver) = mpsc::channel::<Event>(100);
         let shutdown_receiver = shutdown_sender.subscribe();
         let task_master_handle = tokio::spawn(async move {
             fetch_prover_tasks(

--- a/clients/cli/src/prover_runtime.rs
+++ b/clients/cli/src/prover_runtime.rs
@@ -432,7 +432,7 @@ pub fn start_workers(
 #[cfg(test)]
 mod tests {
     use crate::orchestrator::MockOrchestrator;
-    use crate::prover_runtime::{fetch_prover_tasks, Event};
+    use crate::prover_runtime::{Event, fetch_prover_tasks};
     use crate::task::Task;
     use std::time::Duration;
     use tokio::sync::{broadcast, mpsc};

--- a/clients/cli/src/ui/dashboard.rs
+++ b/clients/cli/src/ui/dashboard.rs
@@ -3,10 +3,10 @@
 use crate::environment::Environment;
 use crate::prover_runtime::Event as WorkerEvent;
 use crate::system;
+use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout};
 use ratatui::prelude::{Color, Modifier, Style};
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
-use ratatui::Frame;
 use std::collections::VecDeque;
 use std::time::Instant;
 

--- a/clients/cli/src/ui/dashboard.rs
+++ b/clients/cli/src/ui/dashboard.rs
@@ -1,12 +1,12 @@
 //! Dashboard screen rendering.
 
 use crate::environment::Environment;
+use crate::prover_runtime::Event as WorkerEvent;
 use crate::system;
-use crate::ui::WorkerEvent;
-use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout};
 use ratatui::prelude::{Color, Modifier, Style};
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
+use ratatui::Frame;
 use std::collections::VecDeque;
 use std::time::Instant;
 
@@ -63,6 +63,11 @@ impl DashboardState {
         }
     }
 }
+
+// const SUCCESS_ICON: &str = "✅";
+// const ERROR_ICON: &str = "⚠️";
+// const REFRESH_ICON: &str = "🔄";
+// const SHUTDOWN_ICON: &str = "🔴";
 
 /// Render the dashboard screen.
 pub fn render_dashboard(f: &mut Frame, state: &DashboardState) {
@@ -169,14 +174,7 @@ pub fn render_dashboard(f: &mut Frame, state: &DashboardState) {
     let logs: Vec<String> = state
         .events
         .iter()
-        .map(|event| match event {
-            WorkerEvent::Prover {
-                worker_id: _worker_id,
-                data,
-            } => data.to_string(),
-            WorkerEvent::TaskFetcher { data } => data.to_string(),
-            WorkerEvent::ProofSubmitter { data } => data.to_string(),
-        })
+        .map(|event| format!("[{}] {}", event.timestamp, event.msg))
         .collect();
 
     // Logs using List

--- a/clients/cli/src/ui/mod.rs
+++ b/clients/cli/src/ui/mod.rs
@@ -4,11 +4,11 @@ mod splash;
 
 use crate::environment::Environment;
 use crate::prover_runtime::Event as WorkerEvent;
-use crate::ui::dashboard::{render_dashboard, DashboardState};
+use crate::ui::dashboard::{DashboardState, render_dashboard};
 use crate::ui::login::render_login;
 use crate::ui::splash::render_splash;
 use crossterm::event::{self, Event, KeyCode};
-use ratatui::{backend::Backend, Frame, Terminal};
+use ratatui::{Frame, Terminal, backend::Backend};
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 use tokio::sync::{broadcast, mpsc};

--- a/clients/cli/src/ui/mod.rs
+++ b/clients/cli/src/ui/mod.rs
@@ -3,18 +3,15 @@ mod login;
 mod splash;
 
 use crate::environment::Environment;
-use crate::orchestrator::{Orchestrator, OrchestratorClient};
-use crate::prover_runtime::{WorkerEvent, start_anonymous_workers, start_authenticated_workers};
-use crate::ui::dashboard::{DashboardState, render_dashboard};
+use crate::prover_runtime::Event as WorkerEvent;
+use crate::ui::dashboard::{render_dashboard, DashboardState};
 use crate::ui::login::render_login;
 use crate::ui::splash::render_splash;
 use crossterm::event::{self, Event, KeyCode};
-use ed25519_dalek::SigningKey;
-use ratatui::{Frame, Terminal, backend::Backend};
+use ratatui::{backend::Backend, Frame, Terminal};
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
-use tokio::sync::broadcast;
-use tokio::task::JoinHandle;
+use tokio::sync::{broadcast, mpsc};
 
 /// The different screens in the application.
 #[derive(Debug, Clone)]
@@ -43,40 +40,35 @@ pub struct App {
     /// The environment in which the application is running.
     pub environment: Environment,
 
-    /// The client used to interact with the Nexus Orchestrator.
-    pub orchestrator_client: OrchestratorClient,
-
     /// The current screen being displayed in the application.
     pub current_screen: Screen,
 
     /// Events received from worker threads.
     pub events: VecDeque<WorkerEvent>,
 
-    /// Proof-signing key.
-    signing_key: SigningKey,
+    /// Receives events from worker threads.
+    pub event_receiver: mpsc::Receiver<WorkerEvent>,
 
+    /// Broadcasts shutdown signal to worker threads.
     shutdown_sender: broadcast::Sender<()>,
-    worker_handles: Vec<JoinHandle<()>>,
 }
 
 impl App {
     /// Creates a new instance of the application.
     pub fn new(
         node_id: Option<u64>,
-        orchestrator_client: OrchestratorClient,
-        signing_key: SigningKey,
+        environment: Environment,
+        event_receiver: mpsc::Receiver<WorkerEvent>,
+        shutdown_sender: broadcast::Sender<()>,
     ) -> Self {
-        let (shutdown_sender, _) = broadcast::channel(1); // Only one shutdown signal needed
         Self {
             start_time: Instant::now(),
             node_id,
-            environment: *orchestrator_client.environment(),
-            orchestrator_client,
+            environment,
             current_screen: Screen::Splash,
             events: Default::default(),
-            signing_key,
+            event_receiver,
             shutdown_sender,
-            worker_handles: Vec::new(),
         }
     }
 
@@ -94,28 +86,10 @@ pub async fn run<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> std::i
     let splash_start = Instant::now();
     let splash_duration = Duration::from_secs(2);
 
-    let num_workers = 3; // TODO: Keep this low for now to avoid hitting rate limits.
-
-    // Receives events from prover worker threads.
-    let (mut prover_event_receiver, join_handles) = match app.node_id {
-        Some(node_id) => {
-            start_authenticated_workers(
-                node_id,
-                app.signing_key.clone(),
-                app.orchestrator_client.clone(),
-                num_workers,
-                app.shutdown_sender.subscribe(),
-            )
-            .await
-        }
-        None => start_anonymous_workers(num_workers, app.shutdown_sender.subscribe()).await,
-    };
-    app.worker_handles = join_handles;
-
     // UI event loop
     loop {
         // Drain prover events from the async channel into app.events
-        while let Ok(event) = prover_event_receiver.try_recv() {
+        while let Ok(event) = app.event_receiver.try_recv() {
             if app.events.len() >= MAX_EVENTS {
                 app.events.pop_front();
             }


### PR DESCRIPTION
Starting the CLI with the --headless flag disables the Terminal UI and prints log messages.

Sample output:

```
% cargo run -r start --node-id=5880437 --headless
   Compiling nexus-network v0.8.5 (/Users/mfaulk/projects/network-api/clients/cli)
warning: nexus-network@0.8.5: Skipping proto compilation. Enable with `cargo clean && cargo build --features build_proto`
    Finished `release` profile [optimized] target(s) in 5.37s
     Running `target/release/nexus-network start --node-id=5880437 --headless`
Refresh [2025-06-12 16:06:12] Task Fetcher: Fetched 50 tasks
Success [2025-06-12 16:06:13] Prover 0: Proof completed successfully (Prover 0)
Refresh [2025-06-12 16:06:13] Task Fetcher: Fetched 50 tasks
Error [2025-06-12 16:06:14] Proof Submitter: Failed to submit proof for task 259407338623676441. Status: 404
Refresh [2025-06-12 16:06:14] Task Fetcher: Fetched 50 tasks
Success [2025-06-12 16:06:14] Prover 1: Proof completed successfully (Prover 1)
Error [2025-06-12 16:06:14] Proof Submitter: Failed to submit proof for task 172938225778159968. Status: 404
Success [2025-06-12 16:06:19] Prover 2: Proof completed successfully (Prover 2)
Error [2025-06-12 16:06:19] Proof Submitter: Failed to submit proof for task 201761263393411134. Status: 404
```

Fixes: https://linear.app/nexus-labs/issue/NET-1323/cli-run-as-background-service-non-tui