### PR TITLE
fix: Sets num_workers by clamping max_threads argument

### DIFF
--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -13,7 +13,7 @@ pub mod system;
 mod task;
 mod ui;
 
-use crate::config::{get_config_path, Config};
+use crate::config::{Config, get_config_path};
 use crate::environment::Environment;
 use crate::orchestrator::{Orchestrator, OrchestratorClient};
 use crate::prover_runtime::{start_anonymous_workers, start_authenticated_workers};
@@ -21,10 +21,10 @@ use clap::{ArgAction, Parser, Subcommand};
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},
     execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use ed25519_dalek::SigningKey;
-use ratatui::{backend::CrosstermBackend, Terminal};
+use ratatui::{Terminal, backend::CrosstermBackend};
 use std::{error::Error, io};
 use tokio::sync::broadcast;
 


### PR DESCRIPTION
Configures the number of prover workers based on the --max-threads command line argument. The number of workers is currently clamped to between 1 and 8 to avoid potential issues with backend rate limiting.

Fixes https://linear.app/nexus-labs/issue/NET-1424/cli-re-enable-multithreading