### PR TITLE
fix: Fixes parsing of fibonacci task input

### DIFF
--- a/clients/cli/src/orchestrator/client.rs
+++ b/clients/cli/src/orchestrator/client.rs
@@ -256,7 +256,14 @@ mod live_orchestrator_tests {
         let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
         let verifying_key = signing_key.verifying_key();
         let result = client.get_proof_task(node_id, verifying_key).await;
-        println!("{:?}", result);
+        match result {
+            Ok(task) => {
+                println!("Retrieved task: {:?}", task);
+            }
+            Err(e) => {
+                panic!("Failed to get proof task: {}", e);
+            }
+        }
     }
 
     #[tokio::test]

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -99,12 +99,13 @@ pub async fn authenticated_proving(
 }
 
 fn get_public_input(task: &Task) -> Result<u32, ProverError> {
-    let s = String::from_utf8(task.public_inputs.clone()).map_err(|e| {
-        ProverError::MalformedTask(format!("Failed to convert public inputs to string: {}", e))
-    })?;
-    s.trim()
-        .parse::<u32>()
-        .map_err(|e| ProverError::MalformedTask(format!("Failed to parse public input: {}", e)))
+    // fib_input expects a single public input as a u32.
+    if task.public_inputs.is_empty() {
+        return Err(ProverError::MalformedTask(
+            "Task public inputs are empty".to_string(),
+        ));
+    }
+    Ok(task.public_inputs[0] as u32)
 }
 
 /// Create a Stwo prover for the default program.


### PR DESCRIPTION
Fixes https://linear.app/nexus-labs/issue/NET-1429/cli-malformed-task-failed-to-parse-public-input-invalid-digit-found-in

Before:
```
Error [2025-06-17 14:37:57] Prover 2: Error: Malformed task: Failed to parse public input: invalid digit found in string
```

After:
<img width="1808" alt="Screenshot 2025-06-18 at 1 58 23 PM" src="https://github.com/user-attachments/assets/2e0885be-6216-47fd-b814-49f3f8cf9a2c" />
