### PR TITLE
fix: Better thread shutdown for headless mode

### DIFF
--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -201,20 +201,33 @@ async fn start(
         terminal.show_cursor()?;
 
         res?;
-
-        println!("Exiting...");
-        for handle in join_handles.drain(..) {
-            let _ = handle.await;
-        }
-        println!("Nexus CLI application exited successfully.");
     } else {
-        // Print events to stdout in a loop
+        // Headless mode: log events to console.
+
+        // Trigger shutdown on Ctrl+C
+        let shutdown_sender_clone = shutdown_sender.clone();
+        tokio::spawn(async move {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                let _ = shutdown_sender_clone.send(());
+            }
+        });
+
+        let mut shutdown_receiver = shutdown_sender.subscribe();
         loop {
-            // Drain prover events from the async channel into app.events
-            while let Ok(event) = event_receiver.try_recv() {
-                println!("{}", event);
+            tokio::select! {
+                Some(event) = event_receiver.recv() => {
+                    println!("{}", event);
+                }
+                _ = shutdown_receiver.recv() => {
+                    break;
+                }
             }
         }
     }
+    println!("\nExiting...");
+    for handle in join_handles.drain(..) {
+        let _ = handle.await;
+    }
+    println!("Nexus CLI application exited successfully.");
     Ok(())
 }


### PR DESCRIPTION
Cleanly shuts down worker threads on Ctrl+C when in headless mode. A better main loop significantly reduces CPU usage in headless mode.

Some people have reported that the app doesn't always terminate (quickly?) on Ctrl+C. With this change, the CLI immediately reports "Exiting..." and waits for threads to shut down:

```
Refresh [2025-06-20 17:09:57] Task Fetcher: Fetched 50 tasks
Success [2025-06-20 17:10:00] Prover 0: Proof completed successfully (Prover 0)
^C
Exiting...
Nexus CLI application exited successfully.
```

Fixes https://linear.app/nexus-labs/issue/NET-1479/cli-should-shut-down-worker-threads-on-ctrlc