### PR TITLE
fix: Remove analytics print statements (they break the Terminal UI)

### DIFF
--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -20,10 +20,13 @@ pub enum ProverError {
 
     #[error("Guest Program error: {0}")]
     GuestProgram(String),
+
+    #[error("Analytics tracking error: {0}")]
+    Analytics(String),
 }
 
 /// Proves a program locally with hardcoded inputs.
-pub fn prove_anonymously(
+pub async fn prove_anonymously(
     environment: &Environment,
     client_id: String,
 ) -> Result<Proof, ProverError> {
@@ -55,7 +58,9 @@ pub fn prove_anonymously(
         }),
         environment,
         client_id,
-    );
+    )
+    .await
+    .map_err(|e| ProverError::Analytics(e.to_string()))?;
 
     Ok(proof)
 }
@@ -93,7 +98,9 @@ pub async fn authenticated_proving(
         }),
         environment,
         client_id,
-    );
+    )
+    .await
+    .map_err(|e| ProverError::Analytics(e.to_string()))?;
 
     Ok(proof)
 }

--- a/clients/cli/src/prover_runtime.rs
+++ b/clients/cli/src/prover_runtime.rs
@@ -195,7 +195,7 @@ pub async fn start_anonymous_workers(
 
                     _ = tokio::time::sleep(Duration::from_millis(300)) => {
                         // Perform work
-                        match crate::prover::prove_anonymously(&environment, client_id.clone()) {
+                        match crate::prover::prove_anonymously(&environment, client_id.clone()).await {
                             Ok(_proof) => {
                                 let message = "Anonymous proof completed successfully".to_string();
                                 let _ = prover_event_sender


### PR DESCRIPTION
Removes `eprintln!` statements from the `track` function. Returns a Result instead.

![image](https://github.com/user-attachments/assets/98428b5d-003f-453f-8cff-d7beb629fb14)
