### PR TITLE
ui:LOGS displays "Starting..." if the event log is empty

### DIFF
--- a/clients/cli/src/ui/dashboard.rs
+++ b/clients/cli/src/ui/dashboard.rs
@@ -181,11 +181,15 @@ pub fn render_dashboard(f: &mut Frame, state: &DashboardState) {
         .collect();
 
     // Logs using List
-    let log_items: Vec<ListItem> = logs
+    let mut log_items: Vec<ListItem> = logs
         .iter()
         .rev() // newest first
         .map(|line| ListItem::new(line.clone()))
         .collect();
+
+    if log_items.is_empty() {
+        log_items.push(ListItem::new("Starting...".to_string()));
+    }
 
     let log_widget = List::new(log_items)
         .block(Block::default().title("LOGS").borders(Borders::NONE))


### PR DESCRIPTION
Adds a "Starting..." message to the Dashboard logs. This gives an immediate indication of progress during the first couple of seconds while the CLI fetches initial tasks and processes them. The "Starting..." message disappears when the first log messages arrive

<img width="959" alt="Screenshot 2025-06-25 at 10 56 55 AM" src="https://github.com/user-attachments/assets/49f700c1-d001-4b81-b0fe-b390c2500744" />

Fixes https://linear.app/nexus-labs/issue/NET-1550/cli-dashboard-logs-should-initialize-with-a-starting-message