### PR TITLE
Pretty Print Errors

### DIFF
--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -7,6 +7,7 @@ mod keys;
 #[path = "proto/nexus.orchestrator.rs"]
 mod nexus_orchestrator;
 mod orchestrator;
+mod pretty;
 mod prover;
 mod prover_runtime;
 mod register;

--- a/clients/cli/src/orchestrator/error.rs
+++ b/clients/cli/src/orchestrator/error.rs
@@ -8,6 +8,7 @@ use thiserror::Error;
 struct RawError {
     name: String,
     message: String,
+    #[allow(non_snake_case)] // used for json parsing
     httpCode: u16,
 }
 
@@ -43,7 +44,7 @@ impl OrchestratorError {
                 status: _,
                 message: msg,
             } => {
-                if let Ok(parsed) = serde_json::from_str::<RawError>(&msg) {
+                if let Ok(parsed) = serde_json::from_str::<RawError>(msg) {
                     if let Ok(stringified) = serde_json::to_string_pretty(&parsed) {
                         return Some(stringified);
                     }

--- a/clients/cli/src/orchestrator/error.rs
+++ b/clients/cli/src/orchestrator/error.rs
@@ -1,7 +1,7 @@
 //! Error handling for the orchestrator module
 
 use prost::DecodeError;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[derive(Serialize, Deserialize)]
@@ -39,7 +39,10 @@ impl OrchestratorError {
 
     pub fn to_pretty(&self) -> Option<String> {
         match self {
-            Self::Http { status: _, message: msg } => {
+            Self::Http {
+                status: _,
+                message: msg,
+            } => {
                 if let Ok(parsed) = serde_json::from_str::<RawError>(&msg) {
                     if let Ok(stringified) = serde_json::to_string_pretty(&parsed) {
                         return Some(stringified);
@@ -47,7 +50,7 @@ impl OrchestratorError {
                 }
 
                 None
-            },
+            }
             _ => None,
         }
     }

--- a/clients/cli/src/orchestrator/error.rs
+++ b/clients/cli/src/orchestrator/error.rs
@@ -4,11 +4,11 @@ use prost::DecodeError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+#[allow(non_snake_case)] // used for json parsing
 #[derive(Serialize, Deserialize)]
 struct RawError {
     name: String,
     message: String,
-    #[allow(non_snake_case)] // used for json parsing
     httpCode: u16,
 }
 

--- a/clients/cli/src/pretty.rs
+++ b/clients/cli/src/pretty.rs
@@ -1,0 +1,42 @@
+use crate::ui::splash::LOGO_NAME;
+
+macro_rules! print_cmd_error {
+    ($tt:tt) => {
+        println!("\x1b[1;31m[ERRROR!!!] {}\x1b[0m", $tt);
+        println!("\t\tCheck stderr for raw error content.");
+    };
+    ($tt:tt, $($tts:tt)+) => {
+        println!("\x1b[1;31m[ERRROR!!!] {}\x1b[0m", $tt);
+        println!("\t\t{}", core::format_args!($($tts)*));
+        println!("\t\tCheck stderr for raw error content.");
+    }
+}
+
+macro_rules! handle_cmd_error {
+    ($err:tt, $tt:tt) => {
+        {
+            print_cmd_error!($tt);
+            $err
+        }
+    }
+}
+
+macro_rules! print_cmd_info {
+    ($tt:tt, $($tts:tt)*) => {
+        println!("\x1b[1;33m[INFO!!!] {}\x1b[0m", $tt);
+        println!("\t\t{}", core::format_args!($($tts)*));
+    }
+}
+
+pub(crate) fn print_friendly_error_header() {
+    // RGB: FF = 255, AA = 170, 00 = 0
+    println!("\x1b[38;2;255;170;0m{}\x1b[0m", LOGO_NAME);
+    println!("\x1b[38;2;255;170;0mWe'll be back shortly\x1b[0m");
+    println!(
+        "The Prover network’s orchestrater is under unprecedented traffic. Team has been notified. Thank you for your patience while issue is resolved.\n"
+    );
+}
+
+pub(crate) use print_cmd_error;
+pub(crate) use handle_cmd_error;
+pub(crate) use print_cmd_info;

--- a/clients/cli/src/pretty.rs
+++ b/clients/cli/src/pretty.rs
@@ -15,12 +15,10 @@ macro_rules! print_cmd_error {
 }
 
 macro_rules! handle_cmd_error {
-    ($err:tt, $tt:tt) => {
-        {
-            print_cmd_error!($tt);
-            $err
-        }
-    }
+    ($err:tt, $tt:tt) => {{
+        print_cmd_error!($tt);
+        $err
+    }};
 }
 
 macro_rules! print_cmd_info {
@@ -41,6 +39,6 @@ pub(crate) fn print_friendly_error_header() {
     );
 }
 
-pub(crate) use print_cmd_error;
 pub(crate) use handle_cmd_error;
+pub(crate) use print_cmd_error;
 pub(crate) use print_cmd_info;

--- a/clients/cli/src/pretty.rs
+++ b/clients/cli/src/pretty.rs
@@ -35,7 +35,7 @@ pub(crate) fn print_friendly_error_header() {
     println!("\x1b[38;2;255;170;0m{}\x1b[0m", LOGO_NAME);
     println!("\x1b[38;2;255;170;0mWe'll be back shortly!\x1b[0m");
     println!(
-        "The  orchestrator of the prover network is under unprecedented traffic. The team has been notified. Thank you for your patience while the issue is resolved.\n"
+        "The orchestrator of the prover network is under unprecedented traffic. The team has been notified. Thank you for your patience while the issue is resolved.\n"
     );
 }
 

--- a/clients/cli/src/pretty.rs
+++ b/clients/cli/src/pretty.rs
@@ -17,7 +17,7 @@ macro_rules! print_cmd_error {
 macro_rules! handle_cmd_error {
     ($err:tt, $tt:tt) => {{
         print_cmd_error!($tt);
-        $err
+        format!("{}", $err)
     }};
 }
 

--- a/clients/cli/src/pretty.rs
+++ b/clients/cli/src/pretty.rs
@@ -2,13 +2,15 @@ use crate::ui::splash::LOGO_NAME;
 
 macro_rules! print_cmd_error {
     ($tt:tt) => {
-        println!("\x1b[1;31m[ERRROR!!!] {}\x1b[0m", $tt);
-        println!("\t\tCheck stderr for raw error content.");
+        println!("\x1b[1;31m[ERROR!!!] {}\x1b[0m", $tt);
+        println!("\x1b[1;31m[ERROR!!!]\x1b[0m Raw error being sent to stderr...\n");
     };
     ($tt:tt, $($tts:tt)+) => {
-        println!("\x1b[1;31m[ERRROR!!!] {}\x1b[0m", $tt);
-        println!("\t\t{}", core::format_args!($($tts)*));
-        println!("\t\tCheck stderr for raw error content.");
+        println!("\x1b[1;31m[ERROR!!!] {}\x1b[0m", $tt);
+        println!("\x1b[1;31m[ERROR!!!]\x1b[0m Raw error being sent to stderr...");
+        println!("\x1b[1;31m[ERROR!!!]\x1b[0m Start details...");
+        println!("{}", core::format_args!($($tts)*));
+        println!("\x1b[1;31m[ERROR!!!]\x1b[0m End details.\n");
     }
 }
 
@@ -24,16 +26,18 @@ macro_rules! handle_cmd_error {
 macro_rules! print_cmd_info {
     ($tt:tt, $($tts:tt)*) => {
         println!("\x1b[1;33m[INFO!!!] {}\x1b[0m", $tt);
-        println!("\t\t{}", core::format_args!($($tts)*));
+        println!("\x1b[1;33m[INFO!!!]\x1b[0m Start details...");
+        println!("{}", core::format_args!($($tts)*));
+        println!("\x1b[1;31m[INFO!!!]\x1b[0m End details.\n");
     }
 }
 
 pub(crate) fn print_friendly_error_header() {
     // RGB: FF = 255, AA = 170, 00 = 0
     println!("\x1b[38;2;255;170;0m{}\x1b[0m", LOGO_NAME);
-    println!("\x1b[38;2;255;170;0mWe'll be back shortly\x1b[0m");
+    println!("\x1b[38;2;255;170;0mWe'll be back shortly!\x1b[0m");
     println!(
-        "The Prover network’s orchestrater is under unprecedented traffic. Team has been notified. Thank you for your patience while issue is resolved.\n"
+        "The  orchestrator of the prover network is under unprecedented traffic. The team has been notified. Thank you for your patience while the issue is resolved.\n"
     );
 }
 

--- a/clients/cli/src/register.rs
+++ b/clients/cli/src/register.rs
@@ -2,8 +2,8 @@
 
 use crate::config::Config;
 use crate::keys;
+use crate::pretty::{print_cmd_error, print_cmd_info, handle_cmd_error, print_friendly_error_header};
 use crate::orchestrator::Orchestrator;
-use crate::ui::splash::LOGO_NAME;
 use std::path::Path;
 
 /// Registers a user with the orchestrator.
@@ -19,6 +19,7 @@ pub async fn register_user(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Check if the wallet address is valid.
     if !keys::is_valid_eth_address(wallet_address) {
+        print_cmd_error!("Invalid Ethereum wallet address.");
         let err_msg = format!(
             "Invalid Ethereum wallet address: {}. It should be a 42-character hex string starting with '0x'.",
             wallet_address
@@ -32,8 +33,9 @@ pub async fn register_user(
             if config.wallet_address.to_lowercase() == wallet_address.to_lowercase()
                 && !config.user_id.is_empty()
             {
-                println!(
-                    "User already registered. User ID: {}, Wallet Address: {}",
+                print_cmd_info!(
+                    "User already registered.",
+                    "User ID: {}, Wallet Address: {}",
                     config.user_id, config.wallet_address
                 );
                 return Ok(());
@@ -43,8 +45,9 @@ pub async fn register_user(
 
     // Check if the wallet address is already registered with the orchestrator.
     if let Ok(user_id) = orchestrator.get_user(wallet_address).await {
-        println!(
-            "Wallet address {} is already registered with user ID {}.",
+        print_cmd_info!(
+            "Wallet address is already registered with user ID.",
+            "User ID: {}, Wallet Address: {}",
             wallet_address, user_id
         );
         let config = Config::new(
@@ -56,7 +59,7 @@ pub async fn register_user(
         // Save the configuration file with the user ID and wallet address.
         config
             .save(config_path)
-            .map_err(|e| format!("Failed to save config: {}", e))?;
+            .map_err(|e| handle_cmd_error!(e, "Failed to save config."))?;
 
         return Ok(());
     }
@@ -66,8 +69,8 @@ pub async fn register_user(
     match orchestrator.register_user(&uuid, wallet_address).await {
         Ok(_) => println!("User {} registered successfully.", uuid),
         Err(e) => {
-            print_friendly_error();
-            eprintln!("Failed to register user: {}", e);
+            print_friendly_error_header();
+            print_cmd_error!("Failed to register user.");
             return Err(e.into());
         }
     }
@@ -81,7 +84,7 @@ pub async fn register_user(
     );
     config
         .save(config_path)
-        .map_err(|e| format!("Failed to save config: {}", e))?;
+        .map_err(|e| handle_cmd_error!(e, "Failed to save config."))?;
     Ok(())
 }
 
@@ -101,8 +104,9 @@ pub async fn register_node(
     // If a node_id is provided, update the config with it and use it.
     // If no node_id is provided, generate a new one.
     let mut config = Config::load_from_file(config_path)
-        .map_err(|e| format!("Failed to load config: {}. Please register a user first", e))?;
+        .map_err(|e| handle_cmd_error!(e, "Failed to load config, please register a user first"))?;
     if config.user_id.is_empty() {
+        print_cmd_error!("No user registered. Please register a user first.");
         return Err(Box::from(
             "No user registered. Please register a user first.",
         ));
@@ -113,7 +117,7 @@ pub async fn register_node(
         config.node_id = node_id.to_string();
         config
             .save(config_path)
-            .map_err(|e| format!("Failed to save updated config: {}", e))?;
+            .map_err(|e| handle_cmd_error!(e, "Failed to save updated config."))?;
         println!("Successfully registered node with ID: {}", node_id);
         Ok(())
     } else {
@@ -129,25 +133,16 @@ pub async fn register_node(
                 updated_config.node_id = node_id;
                 updated_config
                     .save(config_path)
-                    .map_err(|e| format!("Failed to save updated config: {}", e))?;
+                    .map_err(|e| handle_cmd_error!(e, "Failed to save updated config."))?;
                 Ok(())
             }
             Err(e) => {
-                print_friendly_error();
-                eprintln!("Failed to register node: {}", e);
+                print_friendly_error_header();
+                print_cmd_error!("Failed to register node.");
                 Err(e.into())
             }
         }
     }
-}
-
-fn print_friendly_error() {
-    // RGB: FF = 255, AA = 170, 00 = 0
-    println!("\x1b[38;2;255;170;0m{}\x1b[0m", LOGO_NAME);
-    println!("\x1b[38;2;255;170;0mWe'll be back shortly\x1b[0m");
-    println!(
-        "The Prover network’s orchestrater is under unprecedented traffic. Team has been notified. Thank you for your patience while issue is resolved.\n"
-    );
 }
 
 #[cfg(test)]

--- a/clients/cli/src/register.rs
+++ b/clients/cli/src/register.rs
@@ -2,8 +2,10 @@
 
 use crate::config::Config;
 use crate::keys;
-use crate::pretty::{print_cmd_error, print_cmd_info, handle_cmd_error, print_friendly_error_header};
 use crate::orchestrator::Orchestrator;
+use crate::pretty::{
+    handle_cmd_error, print_cmd_error, print_cmd_info, print_friendly_error_header,
+};
 use std::path::Path;
 
 /// Registers a user with the orchestrator.
@@ -36,7 +38,8 @@ pub async fn register_user(
                 print_cmd_info!(
                     "User already registered.",
                     "User ID: {}, Wallet Address: {}",
-                    config.user_id, config.wallet_address
+                    config.user_id,
+                    config.wallet_address
                 );
                 return Ok(());
             }
@@ -48,7 +51,8 @@ pub async fn register_user(
         print_cmd_info!(
             "Wallet address is already registered with user ID.",
             "User ID: {}, Wallet Address: {}",
-            wallet_address, user_id
+            wallet_address,
+            user_id
         );
         let config = Config::new(
             user_id,

--- a/clients/cli/src/register.rs
+++ b/clients/cli/src/register.rs
@@ -70,7 +70,12 @@ pub async fn register_user(
         Ok(_) => println!("User {} registered successfully.", uuid),
         Err(e) => {
             print_friendly_error_header();
-            print_cmd_error!("Failed to register user.");
+            if let Some(pretty_error) = e.to_pretty() {
+                print_cmd_error!("Failed to register user.", "{}", pretty_error);
+            } else {
+                print_cmd_error!("Failed to register user. Unable to pretty print error.");
+            }
+
             return Err(e.into());
         }
     }


### PR DESCRIPTION
This PR pretty prints errors with coloring in stdout and references to raw error information being available on stderr.

So eg, at the moment you get something like:

![image](https://github.com/user-attachments/assets/807908b4-949e-419b-8770-42fc8d560698)

This is both redundant and hard to see. Now, you should see something like 

<img width="892" alt="Screenshot 2025-06-26 at 12 58 58 PM" src="https://github.com/user-attachments/assets/27e85566-bc7c-4e06-8994-cfcf9a233051" />

And the bottom raw print out can be suppressed by sending `stderr` to `/dev/null` as normal.