### PR TITLE
fix: Correct mismatched TASK_QUEUE_SIZE constant in online.rs

### DIFF
--- a/clients/cli/src/workers/online.rs
+++ b/clients/cli/src/workers/online.rs
@@ -19,7 +19,7 @@ use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinHandle;
 
 // Task fetching thresholds
-const TASK_QUEUE_SIZE: usize = 50; // Queue sizes from runtime
+const TASK_QUEUE_SIZE: usize = 100; // Queue sizes from runtime
 const BATCH_SIZE: usize = TASK_QUEUE_SIZE / 5; // Fetch this many tasks at once
 const LOW_WATER_MARK: usize = TASK_QUEUE_SIZE / 4; // Fetch new tasks when queue drops below this
 const MAX_404S_BEFORE_GIVING_UP: usize = 5; // Allow several 404s before stopping batch fetch


### PR DESCRIPTION
The `online.rs` worker was using its own `TASK_QUEUE_SIZE` constant (set to 50), while the actual queue in `prover_runtime.rs` was initialized with a capacity of 100.

The core issue was in the queue calculation: `tasks_in_queue = 50 - 100`. This resulted in an integer underflow, making `tasks_in_queue` a massive number.