### PR TITLE
Avoid mismatch constant problem

### DIFF
--- a/clients/cli/src/consts.rs
+++ b/clients/cli/src/consts.rs
@@ -1,0 +1,13 @@
+pub mod prover {
+    // Queue sizes. Chosen to be larger than the tasks API page size (currently, 50)
+    pub const TASK_QUEUE_SIZE: usize = 100;
+    pub const EVENT_QUEUE_SIZE: usize = 100;
+    pub const RESULT_QUEUE_SIZE: usize = 100;
+
+    // Task fetching thresholds
+    pub const BATCH_SIZE: usize = TASK_QUEUE_SIZE / 5; // Fetch this many tasks at once
+    pub const LOW_WATER_MARK: usize = TASK_QUEUE_SIZE / 4; // Fetch new tasks when queue drops below this
+    pub const MAX_404S_BEFORE_GIVING_UP: usize = 5; // Allow several 404s before stopping batch fetch
+    pub const BACKOFF_DURATION: u64 = 30000; // 30 seconds
+    pub const QUEUE_LOG_INTERVAL: u64 = 30000; // 30 seconds
+}

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -2,6 +2,7 @@
 
 mod analytics;
 mod config;
+mod consts;
 mod environment;
 mod error_classifier;
 mod events;

--- a/clients/cli/src/prover_runtime.rs
+++ b/clients/cli/src/prover_runtime.rs
@@ -3,6 +3,7 @@
 //! Main orchestrator for authenticated and anonymous proving modes.
 //! Coordinates online workers (network I/O) and offline workers (computation).
 
+use crate::consts::prover::{EVENT_QUEUE_SIZE, RESULT_QUEUE_SIZE, TASK_QUEUE_SIZE};
 use crate::environment::Environment;
 use crate::events::Event;
 use crate::orchestrator::OrchestratorClient;
@@ -13,11 +14,6 @@ use ed25519_dalek::SigningKey;
 use nexus_sdk::stwo::seq::Proof;
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinHandle;
-
-// Queue sizes. Chosen to be larger than the tasks API page size (currently, 50)
-const TASK_QUEUE_SIZE: usize = 100;
-const EVENT_QUEUE_SIZE: usize = 100;
-const RESULT_QUEUE_SIZE: usize = 100;
 
 /// Maximum number of completed tasks to keep in memory. Chosen to be larger than the task queue size.
 const MAX_COMPLETED_TASKS: usize = 500;

--- a/clients/cli/src/workers/online.rs
+++ b/clients/cli/src/workers/online.rs
@@ -5,6 +5,10 @@
 //! - Proof submission to the orchestrator
 //! - Network error handling with exponential backoff
 
+use crate::consts::prover::{
+    BACKOFF_DURATION, BATCH_SIZE, LOW_WATER_MARK, MAX_404S_BEFORE_GIVING_UP, QUEUE_LOG_INTERVAL,
+    TASK_QUEUE_SIZE,
+};
 use crate::error_classifier::{ErrorClassifier, LogLevel};
 use crate::events::Event;
 use crate::orchestrator::Orchestrator;
@@ -17,14 +21,6 @@ use sha3::{Digest, Keccak256};
 use std::time::Duration;
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinHandle;
-
-// Task fetching thresholds
-const TASK_QUEUE_SIZE: usize = 100; // Queue sizes from runtime
-const BATCH_SIZE: usize = TASK_QUEUE_SIZE / 5; // Fetch this many tasks at once
-const LOW_WATER_MARK: usize = TASK_QUEUE_SIZE / 4; // Fetch new tasks when queue drops below this
-const MAX_404S_BEFORE_GIVING_UP: usize = 5; // Allow several 404s before stopping batch fetch
-const BACKOFF_DURATION: u64 = 30000; // 30 seconds
-const QUEUE_LOG_INTERVAL: u64 = 30000; // 30 seconds
 
 /// State for managing task fetching behavior
 pub struct TaskFetchState {


### PR DESCRIPTION

Summary:

By centralizing constants in one file consts.rs, we minimize mismatched constant bugs from happening again.

Test Plan:
