### PR TITLE
fix: Remove "Using logical cores for FLOPS measurement" print statement

### DIFF
--- a/clients/cli/src/system.rs
+++ b/clients/cli/src/system.rs
@@ -87,8 +87,6 @@ pub fn measure_gflops() -> f32 {
             }
         };
 
-        println!("Using {} logical cores for FLOPS measurement", num_cores);
-
         let avg_flops: f64 = (0..NUM_REPEATS)
             .map(|_| {
                 let start = Instant::now();


### PR DESCRIPTION
The print statement sometimes interferes with rendering the terminal UI:

![image](https://github.com/user-attachments/assets/65a858da-cca8-49a9-abf8-7d5c113ed509)
