### PR TITLE
Fix: Resolve prover deadlock with expiring task cache

### DIFF
--- a/clients/cli/src/consts.rs
+++ b/clients/cli/src/consts.rs
@@ -10,4 +10,7 @@ pub mod prover {
     pub const MAX_404S_BEFORE_GIVING_UP: usize = 5; // Allow several 404s before stopping batch fetch
     pub const BACKOFF_DURATION: u64 = 30000; // 30 seconds
     pub const QUEUE_LOG_INTERVAL: u64 = 30000; // 30 seconds
+
+    /// How long a task ID remains in the duplicate-prevention cache before expiring.
+    pub const CACHE_EXPIRATION: u64 = 300000; // 5 minutes
 }

--- a/clients/cli/src/task_cache.rs
+++ b/clients/cli/src/task_cache.rs
@@ -1,14 +1,16 @@
 //! Cache for recently used task IDs.
 
+use crate::consts::prover::CACHE_EXPIRATION;
 use std::collections::VecDeque;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 
 /// Thread-safe queue of most recent task IDs (bounded).
 #[derive(Clone, Debug)]
 pub struct TaskCache {
     capacity: usize,
-    inner: Arc<Mutex<VecDeque<String>>>,
+    inner: Arc<Mutex<VecDeque<(String, Instant)>>>,
 }
 
 impl TaskCache {
@@ -19,21 +21,33 @@ impl TaskCache {
         }
     }
 
+    /// Prune expired tasks from the cache.
+    async fn prune_expired(&self) {
+        let mut queue = self.inner.lock().await;
+        queue
+            .retain(|(_, timestamp)| timestamp.elapsed() < Duration::from_millis(CACHE_EXPIRATION));
+    }
+
     /// Returns true if the task ID is already in the queue.
     pub async fn contains(&self, task_id: &str) -> bool {
+        self.prune_expired().await;
+
         let queue = self.inner.lock().await;
-        queue.iter().any(|id| id == task_id)
+        queue.iter().any(|(id, _)| id == task_id)
     }
 
     /// Appends a task ID to the queue, evicting the oldest if full.
     pub async fn insert(&self, task_id: String) {
+        self.prune_expired().await;
+
         let mut queue = self.inner.lock().await;
-        if queue.contains(&task_id) {
+        if queue.iter().any(|(id, _)| *id == task_id) {
             return;
         }
         if queue.len() == self.capacity {
             queue.pop_front();
         }
-        queue.push_back(task_id);
+
+        queue.push_back((task_id, Instant::now()));
     }
 }


### PR DESCRIPTION
This PR resolves a critical deadlock issue where workers would get stuck and stop processing tasks.

### The Problem
The root cause was a deadlock scenario triggered when a task failed to be processed by a prover:

1.  A task was fetched, and its ID was immediately added to the `recent_tasks` cache to prevent duplicates.
2.  If the prover worker failed to complete this task for any reason, the task result was never submitted to the server.
3.  The server, not receiving a result, would re-issue the same task to the client.
4.  The `Task Fetcher` would see the task ID in its `recent_tasks` cache, reject it as a duplicate, and enter a backoff loop.

This created an infinite loop where the client would perpetually reject the only task available, effectively starving the prover workers and halting all progress.


### The Solution
The core of this fix is making the `TaskCache` smarter by implementing an expiration mechanism:

* **Expiring Task Cache:** The `TaskCache` in `task_cache.rs` has been updated to store a timestamp (`Instant`) alongside each task ID. A function now prunes any cached entry older than `CACHE_EXPIRATION`. This breaks the deadlock by ensuring that even a "stuck" task ID will eventually be removed from the cache, allowing the worker to retry the task if the server offers it again.