### PR TITLE
chore: update to 0.9.0

### DIFF
--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "nexus-network"
-version = "0.8.18"
+version = "0.9.0"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-network"
-version = "0.8.18"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.85"
 build = "build.rs"


### PR DESCRIPTION
Many of the 0.8.x releases are incompatible with current orchestrator backend, so updating the major version to reflect the need to update.