### PR TITLE
Prevent analytics failures from blocking proof submission

### DIFF
--- a/clients/cli/src/error_classifier.rs
+++ b/clients/cli/src/error_classifier.rs
@@ -50,9 +50,6 @@ impl ErrorClassifier {
 
     pub fn classify_worker_error(&self, error: &ProverError) -> LogLevel {
         match error {
-            // Analytics should never halt operations
-            ProverError::Analytics(_) => LogLevel::Debug,
-
             // Temporary resource issues
             ProverError::Stwo(msg) if msg.contains("memory") => LogLevel::Warn,
             ProverError::Stwo(msg) if msg.contains("timeout") => LogLevel::Warn,

--- a/clients/cli/src/workers/offline.rs
+++ b/clients/cli/src/workers/offline.rs
@@ -5,12 +5,14 @@
 //! - Proof computation (authenticated and anonymous)
 //! - Worker management
 
+use crate::analytics::track;
 use crate::environment::Environment;
 use crate::error_classifier::ErrorClassifier;
 use crate::events::{Event, EventType};
 use crate::prover::authenticated_proving;
 use crate::task::Task;
 use nexus_sdk::stwo::seq::Proof;
+use serde_json::json;
 use std::time::Duration;
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinHandle;
@@ -84,7 +86,7 @@ pub fn start_workers(
                     }
                     // Check if there are tasks to process
                     Some(task) = task_receiver.recv() => {
-                        match authenticated_proving(&task, &environment, client_id.clone()).await {
+                        match authenticated_proving(&task).await {
                             Ok(proof) => {
                                 let message = format!(
                                     "Proof completed successfully (Prover {})",
@@ -93,6 +95,10 @@ pub fn start_workers(
                                 let _ = prover_event_sender
                                     .send(Event::prover(worker_id, message, EventType::Success))
                                     .await;
+
+                                // Track analytics for successful proof (non-blocking)
+                                track_authenticated_proof_analytics(&task, &environment, client_id.clone()).await;
+
                                 let _ = results_sender.send((task, proof)).await;
                             }
                             Err(e) => {
@@ -148,11 +154,14 @@ pub async fn start_anonymous_workers(
 
                     _ = tokio::time::sleep(Duration::from_millis(300)) => {
                         // Perform work
-                        match crate::prover::prove_anonymously(&environment, client_id.clone()).await {
+                        match crate::prover::prove_anonymously().await {
                             Ok(_proof) => {
                                 let message = "Anonymous proof completed successfully".to_string();
                                 let _ = prover_event_sender
                                     .send(Event::prover(worker_id, message, EventType::Success)).await;
+
+                                // Track analytics for successful anonymous proof (non-blocking)
+                                track_anonymous_proof_analytics(&environment, client_id.clone()).await;
                             }
                             Err(e) => {
                                 let log_level = error_classifier.classify_worker_error(&e);
@@ -174,4 +183,83 @@ pub async fn start_anonymous_workers(
     }
 
     (event_receiver, join_handles)
+}
+
+/// Track analytics for authenticated proof (non-blocking)
+async fn track_authenticated_proof_analytics(
+    task: &Task,
+    environment: &Environment,
+    client_id: String,
+) {
+    let analytics_data = match task.program_id.as_str() {
+        "fast-fib" => {
+            // For fast-fib, extract the input from task public_inputs
+            let input = if !task.public_inputs.is_empty() {
+                task.public_inputs[0] as u32
+            } else {
+                0
+            };
+            json!({
+                "program_name": "fast-fib",
+                "public_input": input,
+                "task_id": task.task_id,
+            })
+        }
+        "fib_input_initial" => {
+            // For fib_input_initial, extract the triple inputs
+            let inputs = if task.public_inputs.len() >= 12 {
+                let mut bytes = [0u8; 4];
+                bytes.copy_from_slice(&task.public_inputs[0..4]);
+                let n = u32::from_le_bytes(bytes);
+                bytes.copy_from_slice(&task.public_inputs[4..8]);
+                let init_a = u32::from_le_bytes(bytes);
+                bytes.copy_from_slice(&task.public_inputs[8..12]);
+                let init_b = u32::from_le_bytes(bytes);
+                (n, init_a, init_b)
+            } else {
+                (0, 0, 0)
+            };
+            json!({
+                "program_name": "fib_input_initial",
+                "public_input": inputs.0,
+                "public_input_2": inputs.1,
+                "public_input_3": inputs.2,
+                "task_id": task.task_id,
+            })
+        }
+        _ => {
+            json!({
+                "program_name": task.program_id,
+                "task_id": task.task_id,
+            })
+        }
+    };
+
+    let _ = track(
+        "cli_proof_node_v3".to_string(),
+        analytics_data,
+        environment,
+        client_id,
+    )
+    .await;
+
+}
+
+/// Track analytics for anonymous proof (non-blocking)
+async fn track_anonymous_proof_analytics(environment: &Environment, client_id: String) {
+    // Anonymous proofs use hardcoded input: (n=9, init_a=1, init_b=1)
+    let public_input = (9, 1, 1);
+
+    let _ =track(
+        "cli_proof_anon_v3".to_string(),
+        json!({
+            "program_name": "fib_input_initial",
+            "public_input": public_input.0,
+            "public_input_2": public_input.1,
+            "public_input_3": public_input.2,
+        }),
+        environment,
+        client_id,
+    )
+    .await;
 }


### PR DESCRIPTION

# Summary
## Original Bug:

When sending analytics to Google Analytics, if the network request fails or is blocked, the Prover would return an error and halt the entire task pipeline, preventing proof submission.

## Fix:

- *Architectural separation*: Moved analytics tracking from `prover.rs` to the orchestration layer (`offline.rs`).

- *Non-blocking analytics*: Analytics failures no longer return errors and cannot interrupt proof generation or submission

- *Fire-and-forget approach*: Analytics requests are sent asynchronously without caring about success/failure status
