### PR TITLE
feat: use node id for analytics

### DIFF
--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "nexus-network"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-network"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 rust-version = "1.85"
 build = "build.rs"

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -155,19 +155,21 @@ async fn start(
     let client_id = if config_path.exists() {
         match Config::load_from_file(&config_path) {
             Ok(config) => {
-                // First try user_id, then node_id, then fallback to UUID
-                if !config.user_id.is_empty() {
-                    config.user_id
-                } else if !config.node_id.is_empty() {
-                    config.node_id
+                // If user has a node_id, use "cli-{node_id}" format
+                if !config.node_id.is_empty() {
+                    format!("cli-{}", config.node_id)
+                } else if !config.user_id.is_empty() {
+                    // Fallback to user_id if no node_id but user is registered
+                    format!("cli-{}", config.user_id)
                 } else {
-                    uuid::Uuid::new_v4().to_string() // Fallback to random UUID
+                    // No node_id or user_id - this shouldn't happen with current flow
+                    "anonymous".to_string()
                 }
             }
-            Err(_) => uuid::Uuid::new_v4().to_string(), // Fallback to random UUID
+            Err(_) => "anonymous".to_string(), // Fallback to anonymous
         }
     } else {
-        uuid::Uuid::new_v4().to_string() // Fallback to random UUID
+        "anonymous".to_string() // No config file = anonymous user
     };
 
     let (mut event_receiver, mut join_handles) = match node_id {


### PR DESCRIPTION
We used to persist a UUID to disk to uniquely identify the install of the CLI.

Now we use the node id, or "anonymous"