### PR TITLE
feat: point CLI clients to production.orchestrator

### DIFF
--- a/clients/cli/src/environment.rs
+++ b/clients/cli/src/environment.rs
@@ -19,7 +19,7 @@ impl Environment {
         match self {
             Environment::Local => "http://localhost:50505".to_string(),
             Environment::Staging => "https://staging.orchestrator.nexus.xyz".to_string(),
-            Environment::Beta => "https://beta.orchestrator.nexus.xyz".to_string(),
+            Environment::Beta => "https://production.orchestrator.nexus.xyz".to_string(),
         }
     }
 }

--- a/tests/test_updater.sh
+++ b/tests/test_updater.sh
@@ -18,7 +18,7 @@
 set -e  # Exit on any error
 
 # Configuration
-ORCHESTRATOR_HOST="beta.orchestrator.nexus.xyz"
+ORCHESTRATOR_HOST="production.orchestrator.nexus.xyz"
 # The new version number used to test the updater
 TEST_NEW_VERSION="0.9.9" 
 


### PR DESCRIPTION
In order to successfully migrate our backend to using Ingress, we need to port the CLI client to production.orchestrator.nexus.xyz, which internally points to the Ingress controller. This requires changes to the ORCHESTRATOR_URL that the client uses.