### PR TITLE
docs (README.md): update link to nexus.xyz on pic

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 A high-performance command-line interface for contributing proofs to the Nexus network.
 
 <figure>
-    <a href="https://beta.nexus.xyz/">
+    <a href="https://nexus.xyz/">
         <img src="assets/images/nexus-network-image.png" alt="Nexus Network visualization showing a distributed network of interconnected nodes with a 'Launch Network' button in the center">
     </a>
     <figcaption>


### PR DESCRIPTION
now if u press on picture you will be redirected to https://nexus.xyz/ . 

changed because previous link is not avaible (old domain)

<img width="1280" height="643" alt="image" src="https://github.com/user-attachments/assets/37cb71ce-d50f-41b8-bc64-48f24d4e2428" />
