### PR TITLE
test(updater): Correct log step numbering 

### DIFF
--- a/tests/test_updater.sh
+++ b/tests/test_updater.sh
@@ -145,9 +145,9 @@ fi
 
 # If the new PID is the same as the original PID, the CLI was not restarted (same process)
 if [ "$NEW_PID" == "$ORIGINAL_PID" ]; then
-    echo -e "${ORANGE}[test-updater script] (12 / 18) ❌ CLI was not restarted \(PID unchanged\)${NC}"
-    echo -e "${ORANGE}[test-updater script] (13 / 18) Original version: $(git describe --tags $STARTING_COMMIT)${NC}. Expected version: $TEST_NEW_VERSION${NC}"
+    echo -e "${ORANGE}[test-updater script] (11 / 18) ❌ CLI was not restarted \(PID unchanged\)${NC}"
+    echo -e "${ORANGE}[test-updater script] (12 / 18) Original version: $(git describe --tags $STARTING_COMMIT)${NC}. Expected version: $TEST_NEW_VERSION${NC}"
     exit 1
 fi
 
-echo -e "${ORANGE}[test-updater script] (14 / 18) ✅ CLI auto-updated and restarted successfully${NC}"
+echo -e "${ORANGE}[test-updater script] (13 / 18) ✅ CLI auto-updated and restarted successfully${NC}"


### PR DESCRIPTION
## Summary

This PR fixes the inconsistent and non-sequential log step numbering in the tests/test_updater.sh script. The goal is to improve the clarity and debuggability of the test script's output without changing its core logic.

## Background

While reviewing the updater test script, I noticed that the numbered log messages, which are helpful for tracing execution, were out of order. Specifically:

The script jumped from step 10 to step 12 in the failure path.

Step 11 was missing entirely.

Step 13 was the success message, but step 14 began the cleanup block, which could be confusing if the script ran to completion.

This inconsistency can make it difficult to quickly diagnose where the script failed or to follow its flow.

## Changes Made

Renumbered Log Steps: All [test-updater script] (X / 18) messages in tests/test_updater.sh have been renumbered to be perfectly sequential from start to finish.

The failure path now correctly uses steps 11 and 12.

The success message is now step 13.

The cleanup function starts at step 14.