### PR TITLE
fix(proto): Correct field name and comment in GetProofTaskRequest

### DIFF
--- a/proto/orchestrator.proto
+++ b/proto/orchestrator.proto
@@ -70,7 +70,7 @@ message GetProofTaskRequest {
   NodeType node_type = 2;
 
   // The client's Ed25519 public key for proof authentication.Add commentMore actions
-  bytes ed25519PublicKey = 3;
+  bytes ed25519_public_key = 3;
 }
 
 // A Prover task.


### PR DESCRIPTION
The `GetProof-Task-Request` message contained a field named `ed25519PublicKey`, which used camelCase instead of the standard snake_case convention for Protobuf fields.

This commit renames the field to `ed25519_public_key` to align with the [Google Protobuf style guide](https://protobuf.dev/programming-guides/style/#message-and-field-names).