### PR TITLE
Make analytics functions truly non-blocking with `tokio::spawn`

### DIFF
--- a/clients/cli/src/analytics.rs
+++ b/clients/cli/src/analytics.rs
@@ -1,5 +1,6 @@
 use crate::environment::Environment;
 use crate::system::{estimate_peak_gflops, measure_gflops, num_cores};
+use crate::task::Task;
 use chrono::Datelike;
 use chrono::Timelike;
 use reqwest::header::ACCEPT;
@@ -142,11 +143,7 @@ pub async fn track(
 }
 
 /// Track analytics for getting a task from orchestrator (non-blocking)
-pub async fn track_got_task(
-    task: &crate::task::Task,
-    environment: &Environment,
-    client_id: String,
-) {
+pub async fn track_got_task(task: crate::task::Task, environment: Environment, client_id: String) {
     let analytics_data = json!({
         "program_name": task.program_id,
         "task_id": task.task_id,
@@ -155,7 +152,7 @@ pub async fn track_got_task(
     let _ = track(
         vec!["cli_got_task".to_string(), "got_task".to_string()],
         analytics_data,
-        environment,
+        &environment,
         client_id,
     )
     .await;
@@ -164,9 +161,9 @@ pub async fn track_got_task(
 
 /// Track analytics for proof verification failure (non-blocking)
 pub async fn track_verification_failed(
-    task: &crate::task::Task,
-    error: &str,
-    environment: &Environment,
+    task: crate::task::Task,
+    error: String,
+    environment: Environment,
     client_id: String,
 ) {
     let analytics_data = json!({
@@ -181,7 +178,7 @@ pub async fn track_verification_failed(
             "local_verification_failed".to_string(),
         ],
         analytics_data,
-        environment,
+        &environment,
         client_id,
     )
     .await;
@@ -190,10 +187,10 @@ pub async fn track_verification_failed(
 
 /// Track analytics for proof submission error (non-blocking)
 pub async fn track_proof_submission_error(
-    task: &crate::task::Task,
-    error: &str,
+    task: crate::task::Task,
+    error: String,
     status_code: Option<u16>,
-    environment: &Environment,
+    environment: Environment,
     client_id: String,
 ) {
     let mut analytics_data = json!({
@@ -212,7 +209,7 @@ pub async fn track_proof_submission_error(
             "proof_submission_error".to_string(),
         ],
         analytics_data,
-        environment,
+        &environment,
         client_id,
     )
     .await;
@@ -221,8 +218,8 @@ pub async fn track_proof_submission_error(
 
 /// Track analytics for proof acceptance (non-blocking)
 pub async fn track_proof_accepted(
-    task: &crate::task::Task,
-    environment: &Environment,
+    task: crate::task::Task,
+    environment: Environment,
     client_id: String,
 ) {
     let analytics_data = json!({
@@ -236,7 +233,7 @@ pub async fn track_proof_accepted(
             "proof_accepted".to_string(),
         ],
         analytics_data,
-        environment,
+        &environment,
         client_id,
     )
     .await;
@@ -245,8 +242,8 @@ pub async fn track_proof_accepted(
 
 /// Track analytics for proof submission success (non-blocking)
 pub async fn track_proof_submission_success(
-    task: &crate::task::Task,
-    environment: &Environment,
+    task: crate::task::Task,
+    environment: Environment,
     client_id: String,
 ) {
     let analytics_data = json!({
@@ -260,7 +257,87 @@ pub async fn track_proof_submission_success(
             "proof_submission_success".to_string(),
         ],
         analytics_data,
-        environment,
+        &environment,
+        client_id,
+    )
+    .await;
+    // TODO: Catch errors and log them
+}
+
+/// Track analytics for authenticated proof (non-blocking)
+pub async fn track_authenticated_proof_analytics(
+    task: Task,
+    environment: Environment,
+    client_id: String,
+) {
+    let analytics_data = match task.program_id.as_str() {
+        "fast-fib" => {
+            // For fast-fib, extract the input from task public_inputs
+            let input = if !task.public_inputs.is_empty() {
+                task.public_inputs[0] as u32
+            } else {
+                0
+            };
+            json!({
+                "program_name": "fast-fib",
+                "public_input": input,
+                "task_id": task.task_id,
+            })
+        }
+        "fib_input_initial" => {
+            // For fib_input_initial, extract the triple inputs
+            let inputs = if task.public_inputs.len() >= 12 {
+                let mut bytes = [0u8; 4];
+                bytes.copy_from_slice(&task.public_inputs[0..4]);
+                let n = u32::from_le_bytes(bytes);
+                bytes.copy_from_slice(&task.public_inputs[4..8]);
+                let init_a = u32::from_le_bytes(bytes);
+                bytes.copy_from_slice(&task.public_inputs[8..12]);
+                let init_b = u32::from_le_bytes(bytes);
+                (n, init_a, init_b)
+            } else {
+                (0, 0, 0)
+            };
+            json!({
+                "program_name": "fib_input_initial",
+                "public_input": inputs.0,
+                "public_input_2": inputs.1,
+                "public_input_3": inputs.2,
+                "task_id": task.task_id,
+            })
+        }
+        _ => {
+            json!({
+                "program_name": task.program_id,
+                "task_id": task.task_id,
+            })
+        }
+    };
+
+    let _ = track(
+        vec!["cli_proof_node_v4".to_string(), "proof_node".to_string()],
+        analytics_data,
+        &environment,
+        client_id,
+    )
+    .await;
+    // TODO: Catch errors and log them
+}
+
+/// Track analytics for anonymous proof (non-blocking)
+pub async fn track_anonymous_proof_analytics(environment: Environment, client_id: String) {
+    // Anonymous proofs use hardcoded input: (n=9, init_a=1, init_b=1)
+    let public_input = (9, 1, 1);
+
+    let _ = track(
+        vec!["cli_proof_anon_v3".to_string()],
+        json!({
+            "program_name": "fib_input_initial",
+            "public_input": public_input.0,
+            "public_input_2": public_input.1,
+            "public_input_3": public_input.2,
+        }),
+        &environment,
         client_id,
     )
     .await;

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -86,8 +86,12 @@ pub async fn authenticated_proving(
                     let error_msg =
                         format!("Failed to verify proof: {} for inputs: {:?}", e, input);
                     // Track analytics for verification failure (non-blocking)
-                    track_verification_failed(task, &error_msg, environment, client_id.to_string())
-                        .await;
+                    tokio::spawn(track_verification_failed(
+                        task.clone(),
+                        error_msg.clone(),
+                        environment.clone(),
+                        client_id.to_string(),
+                    ));
                     return Err(ProverError::Stwo(error_msg));
                 }
             }
@@ -118,8 +122,12 @@ pub async fn authenticated_proving(
                     let error_msg =
                         format!("Failed to verify proof: {} for inputs: {:?}", e, inputs);
                     // Track analytics for verification failure (non-blocking)
-                    track_verification_failed(task, &error_msg, environment, client_id.to_string())
-                        .await;
+                    tokio::spawn(track_verification_failed(
+                        task.clone(),
+                        error_msg.clone(),
+                        environment.clone(),
+                        client_id.to_string(),
+                    ));
                     return Err(ProverError::Stwo(error_msg));
                 }
             }

--- a/clients/cli/src/workers/online.rs
+++ b/clients/cli/src/workers/online.rs
@@ -318,7 +318,11 @@ async fn process_fetched_tasks(
         }
 
         // Track analytics for getting a task (non-blocking)
-        track_got_task(&task, environment, client_id.to_string()).await;
+        tokio::spawn(track_got_task(
+            task.clone(),
+            environment.clone(),
+            client_id.to_string(),
+        ));
 
         added_count += 1;
     }
@@ -700,7 +704,11 @@ async fn process_proof_submission(
     {
         Ok(_) => {
             // Track analytics for proof submission success (non-blocking)
-            track_proof_submission_success(&task, environment, client_id.to_string()).await;
+            tokio::spawn(track_proof_submission_success(
+                task.clone(),
+                environment.clone(),
+                client_id.to_string(),
+            ));
             handle_submission_success(
                 &task,
                 event_sender,
@@ -732,7 +740,11 @@ async fn handle_submission_success(
         task.task_id
     );
     // Track analytics for proof acceptance (non-blocking)
-    track_proof_accepted(task, environment, client_id.to_string()).await;
+    tokio::spawn(track_proof_accepted(
+        task.clone(),
+        environment.clone(),
+        client_id.to_string(),
+    ));
 
     let _ = event_sender
         .send(Event::proof_submitter_with_level(
@@ -766,7 +778,13 @@ async fn handle_submission_error(
     };
 
     // Track analytics for proof submission error (non-blocking)
-    track_proof_submission_error(task, &msg, status_code, environment, client_id.to_string()).await;
+    tokio::spawn(track_proof_submission_error(
+        task.clone(),
+        msg.clone(),
+        status_code,
+        environment.clone(),
+        client_id.to_string(),
+    ));
 
     let _ = event_sender
         .send(Event::proof_submitter(


### PR DESCRIPTION

Make analytics functions truly non-blocking with tokio::spawn

Previously, analytics functions were commented as "non-blocking" but were
actually blocking the main execution flow by using .await, which waited
for HTTP requests to complete before continuing.

Changes:
- Update analytics function signatures to take owned values instead of references
- Use tokio::spawn at all call sites for fire-and-forget analytics
- Apply consistent pattern across `prover.rs`, `workers/online.rs`, and `workers/offline.rs`

Benefits:
- Proof verification and submission now happen at full speed
- Analytics HTTP requests run in background without delaying core functionality
- Failed analytics requests no longer impact prover reliability
- Comments now match actual non-blocking implementation

This ensures analytics are truly fire-and-forget as intended, improving
overall prover performance and user experience.
