### PR TITLE
refactor(environment): optimize orchestrator_url() to return &str instead of String

### DIFF
--- a/clients/cli/src/environment.rs
+++ b/clients/cli/src/environment.rs
@@ -13,10 +13,10 @@ pub enum Environment {
 
 impl Environment {
     /// Returns the orchestrator service URL associated with the environment.
-    pub fn orchestrator_url(&self) -> String {
+    pub fn orchestrator_url(&self) -> &str {
         match self {
-            Environment::Production => "https://production.orchestrator.nexus.xyz".to_string(),
-            Environment::Custom { orchestrator_url } => orchestrator_url.clone(),
+            Environment::Production => "https://production.orchestrator.nexus.xyz",
+            Environment::Custom { orchestrator_url } => orchestrator_url,
         }
     }
 }


### PR DESCRIPTION
eliminates unnecessary string cloning in the orchestrator_url() method by returning string references instead of owned strings. This improves performance by avoiding memory allocations, especially in code paths where this method is called
frequently. The method is used in critical network request paths, so this optimization can have a positive impact on overall CLI performance