### PR TITLE
Add progressive guided onboarding flow

### DIFF
--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -25,6 +25,7 @@ mod workers;
 use crate::config::{Config, get_config_path};
 use crate::environment::Environment;
 use crate::orchestrator::{Orchestrator, OrchestratorClient};
+use crate::pretty::print_cmd_info;
 use crate::prover_runtime::{start_anonymous_workers, start_authenticated_workers};
 use crate::register::{register_node, register_user};
 use clap::{ArgAction, Parser, Subcommand};
@@ -124,11 +125,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .await
         }
         Command::Logout => {
-            println!("Logging out and clearing node configuration file...");
+            print_cmd_info!("Logging out", "Clearing node configuration file...");
             Config::clear_node_config(&config_path).map_err(Into::into)
         }
         Command::RegisterUser { wallet_address } => {
-            println!("Registering user with wallet address: {}", wallet_address);
+            print_cmd_info!("Registering user", "Wallet address: {}", wallet_address);
             let orchestrator = Box::new(OrchestratorClient::new(environment));
             register_user(&wallet_address, &config_path, orchestrator).await
         }
@@ -156,19 +157,51 @@ async fn start(
     no_background_color: bool,
 ) -> Result<(), Box<dyn Error>> {
     let mut node_id = node_id;
+
     // If no node ID is provided, try to load it from the config file.
     if node_id.is_none() && config_path.exists() {
         let config = Config::load_from_file(&config_path)?;
-        node_id = Some(config.node_id.parse::<u64>().map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!(
-                    "Failed to parse node_id {:?} from the config file as a u64: {}",
-                    config.node_id, e
-                ),
-            )
-        })?);
-        println!("Read Node ID: {} from config file\n", node_id.unwrap());
+
+        // Check if user is registered but node_id is missing or invalid
+        if !config.user_id.is_empty() {
+            if config.node_id.is_empty() {
+                print_cmd_info!(
+                    "✅ User registered, but no node found.",
+                    "Please register a node to continue: nexus-cli register-node"
+                );
+                return Err(
+                    "Node registration required. Please run 'nexus-cli register-node' first."
+                        .into(),
+                );
+            }
+
+            match config.node_id.parse::<u64>() {
+                Ok(id) => {
+                    node_id = Some(id);
+                    print_cmd_info!("✅ Found Node ID from config file", "Node ID: {}", id);
+                }
+                Err(_) => {
+                    print_cmd_info!(
+                        "❌ Invalid node ID in config file.",
+                        "Please register a new node: nexus-cli register-node"
+                    );
+                    return Err("Invalid node ID in config. Please run 'nexus-cli register-node' to fix this.".into());
+                }
+            }
+        } else {
+            print_cmd_info!(
+                "❌ No user registration found.",
+                "Please register your wallet address first: nexus-cli register-user --wallet-address <your-wallet-address>"
+            );
+            return Err("User registration required. Please run 'nexus-cli register-user --wallet-address <your-wallet-address>' first.".into());
+        }
+    } else if node_id.is_none() {
+        // No config file exists at all
+        print_cmd_info!(
+            "Welcome to Nexus CLI!",
+            "Please register your wallet address to get started: nexus-cli register-user --wallet-address <your-wallet-address>"
+        );
+        return Err("User registration required. Please run 'nexus-cli register-user --wallet-address <your-wallet-address>' first.".into());
     }
 
     // Create a signing key for the prover.

--- a/clients/cli/src/pretty.rs
+++ b/clients/cli/src/pretty.rs
@@ -24,9 +24,7 @@ macro_rules! handle_cmd_error {
 macro_rules! print_cmd_info {
     ($tt:tt, $($tts:tt)*) => {
         println!("\x1b[1;33m[INFO!!!] {}\x1b[0m", $tt);
-        println!("\x1b[1;33m[INFO!!!]\x1b[0m Start details...");
         println!("{}", core::format_args!($($tts)*));
-        println!("\x1b[1;31m[INFO!!!]\x1b[0m End details.\n");
     }
 }
 

--- a/clients/cli/src/register.rs
+++ b/clients/cli/src/register.rs
@@ -21,7 +21,7 @@ pub async fn register_user(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Check if the wallet address is valid.
     if !keys::is_valid_eth_address(wallet_address) {
-        print_cmd_error!("Invalid Ethereum wallet address.");
+        print_cmd_error!("❌ Invalid Ethereum wallet address.");
         let err_msg = format!(
             "Invalid Ethereum wallet address: {}. It should be a 42-character hex string starting with '0x'.",
             wallet_address
@@ -40,6 +40,12 @@ pub async fn register_user(
                     "User ID: {}, Wallet Address: {}",
                     config.user_id,
                     config.wallet_address
+                );
+
+                // Guide user to next step
+                print_cmd_info!(
+                    "✅ User registration complete!",
+                    "Next step - register a node: nexus-cli register-node"
                 );
                 return Ok(());
             }
@@ -64,6 +70,12 @@ pub async fn register_user(
         config
             .save(config_path)
             .map_err(|e| handle_cmd_error!(e, "Failed to save config."))?;
+
+        // Guide user to next step
+        print_cmd_info!(
+            "✅ User registration complete!",
+            "Next step - register a node: nexus-cli register-node"
+        );
 
         return Ok(());
     }
@@ -94,6 +106,13 @@ pub async fn register_user(
     config
         .save(config_path)
         .map_err(|e| handle_cmd_error!(e, "Failed to save config."))?;
+
+    // Guide user to next step
+    print_cmd_info!(
+        "✅ User registration complete!",
+        "Next step - register a node: nexus-cli register-node"
+    );
+
     Ok(())
 }
 
@@ -115,7 +134,7 @@ pub async fn register_node(
     let mut config = Config::load_from_file(config_path)
         .map_err(|e| handle_cmd_error!(e, "Failed to load config, please register a user first"))?;
     if config.user_id.is_empty() {
-        print_cmd_error!("No user registered. Please register a user first.");
+        print_cmd_error!("❌ No user registered. Please register a user first.");
         return Err(Box::from(
             "No user registered. Please register a user first.",
         ));
@@ -127,7 +146,14 @@ pub async fn register_node(
         config
             .save(config_path)
             .map_err(|e| handle_cmd_error!(e, "Failed to save updated config."))?;
-        println!("Successfully registered node with ID: {}", node_id);
+
+        // Guide user to next step
+        print_cmd_info!(
+            "✅ Node registration complete!",
+            "Successfully registered node with ID: {}. Next step - start proving: nexus-cli start",
+            node_id
+        );
+
         Ok(())
     } else {
         println!(
@@ -136,13 +162,20 @@ pub async fn register_node(
         );
         match orchestrator.register_node(&config.user_id).await {
             Ok(node_id) => {
-                println!("Node registered successfully with ID: {}", node_id);
                 // Update the config with the new node ID
                 let mut updated_config = config;
-                updated_config.node_id = node_id;
+                updated_config.node_id = node_id.clone();
                 updated_config
                     .save(config_path)
                     .map_err(|e| handle_cmd_error!(e, "Failed to save updated config."))?;
+
+                // Guide user to next step
+                print_cmd_info!(
+                    "✅ Node registration complete!",
+                    "Successfully registered node with ID: {}. Next step - start proving: nexus-cli start",
+                    node_id
+                );
+
                 Ok(())
             }
             Err(e) => {


### PR DESCRIPTION

- Add step-by-step guidance in start command that shows only the next required action
- Update register_user to display next step guidance after successful registration
- Update register_node to display next step guidance after successful registration
- Replace all println! with print_cmd_info! for consistent user message formatting

Users now get a smooth progressive experience:
1. Run 'nexus-cli start' → guided to register wallet
2. Run 'nexus-cli register-user' → guided to register node
3. Run 'nexus-cli register-node' → guided to start proving
4. Run 'nexus-cli start' → begins proving automatically

This eliminates confusion by showing only one step at a time instead of overwhelming users with all steps upfront.
