### PR TITLE
feat: X-Build-Timestamp and User-Agent headers for orchestrator requests

### DIFF
--- a/clients/cli/build.rs
+++ b/clients/cli/build.rs
@@ -6,6 +6,14 @@ use std::{env, path::Path};
 
 /// Compiles the protobuf files into Rust code using prost-build.
 fn main() -> Result<(), Box<dyn Error>> {
+    // Set build timestamp in milliseconds since epoch
+    let build_timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis()
+        .to_string();
+    println!("cargo:rustc-env=BUILD_TIMESTAMP={}", build_timestamp);
+
     // Skip proto compilation unless build_proto feature is enabled.
     if !cfg!(feature = "build_proto") {
         println!(

--- a/clients/cli/src/orchestrator/client.rs
+++ b/clients/cli/src/orchestrator/client.rs
@@ -17,6 +17,9 @@ use reqwest::{Client, ClientBuilder, Response};
 use std::sync::OnceLock;
 use std::time::Duration;
 
+// Build timestamp in milliseconds since epoch
+const BUILD_TIMESTAMP: &str = env!("BUILD_TIMESTAMP", "Build timestamp not available");
+
 // Privacy-preserving country detection for network optimization.
 // Only stores 2-letter country codes (e.g., "US", "CA", "GB") to help route
 // requests to the nearest Nexus network servers for better performance.
@@ -69,7 +72,12 @@ impl OrchestratorClient {
         endpoint: &str,
     ) -> Result<T, OrchestratorError> {
         let url = self.build_url(endpoint);
-        let response = self.client.get(&url).send().await?;
+        let response = self
+            .client
+            .get(&url)
+            .header("X-Build-Timestamp", BUILD_TIMESTAMP)
+            .send()
+            .await?;
 
         let response = Self::handle_response_status(response).await?;
         let response_bytes = response.bytes().await?;
@@ -86,6 +94,7 @@ impl OrchestratorClient {
             .client
             .post(&url)
             .header("Content-Type", "application/octet-stream")
+            .header("X-Build-Timestamp", BUILD_TIMESTAMP)
             .body(body)
             .send()
             .await?;
@@ -105,6 +114,7 @@ impl OrchestratorClient {
             .client
             .post(&url)
             .header("Content-Type", "application/octet-stream")
+            .header("X-Build-Timestamp", BUILD_TIMESTAMP)
             .body(body)
             .send()
             .await?;

--- a/clients/cli/src/orchestrator/client.rs
+++ b/clients/cli/src/orchestrator/client.rs
@@ -20,6 +20,9 @@ use std::time::Duration;
 // Build timestamp in milliseconds since epoch
 const BUILD_TIMESTAMP: &str = env!("BUILD_TIMESTAMP", "Build timestamp not available");
 
+// User-Agent string with CLI version
+const USER_AGENT: &str = concat!("nexus-cli/", env!("CARGO_PKG_VERSION"));
+
 // Privacy-preserving country detection for network optimization.
 // Only stores 2-letter country codes (e.g., "US", "CA", "GB") to help route
 // requests to the nearest Nexus network servers for better performance.
@@ -75,6 +78,7 @@ impl OrchestratorClient {
         let response = self
             .client
             .get(&url)
+            .header("User-Agent", USER_AGENT)
             .header("X-Build-Timestamp", BUILD_TIMESTAMP)
             .send()
             .await?;
@@ -94,6 +98,7 @@ impl OrchestratorClient {
             .client
             .post(&url)
             .header("Content-Type", "application/octet-stream")
+            .header("User-Agent", USER_AGENT)
             .header("X-Build-Timestamp", BUILD_TIMESTAMP)
             .body(body)
             .send()
@@ -114,6 +119,7 @@ impl OrchestratorClient {
             .client
             .post(&url)
             .header("Content-Type", "application/octet-stream")
+            .header("User-Agent", USER_AGENT)
             .header("X-Build-Timestamp", BUILD_TIMESTAMP)
             .body(body)
             .send()


### PR DESCRIPTION
All orchestrator API calls now include:

## User-Agent

User-Agent: nexus-cli/{version} (e.g., nexus-cli/0.10.1)

## X-Build-Timestamp: Build timestamp in milliseconds since epoch

- Add BUILD_TIMESTAMP constant using env! macro
- Set build timestamp in milliseconds since epoch during build process
- Add `X-Build-Timestamp` header to all HTTP requests:
  * GET requests (get_request)
  * POST requests (post_request)
  * POST requests without response (post_request_no_response)
- Build timestamp is set in build.rs using SystemTime::now()
- Header value is in milliseconds since Unix epoch

## Content-Type

Content-Type: application/octet-stream (for POST requests)

Pre-existing
