### PR TITLE
chore: Repair Step Messaging

### DIFF
--- a/clients/cli/src/workers/online.rs
+++ b/clients/cli/src/workers/online.rs
@@ -149,9 +149,9 @@ async fn attempt_task_fetch(
 ) -> Result<(), bool> {
     let _ = event_sender
         .send(Event::task_fetcher_with_level(
-            "[Task step 1 of 3] Fetching tasks...Note: CLI tasks are harder to solve, so they receive 10 times more points than web provers".to_string(),
+            "[Task step 1 of 3] Fetching tasks... Note: CLI tasks are harder to solve, so they receive 10 times more points than web provers".to_string(),
             crate::events::EventType::Refresh,
-            LogLevel::Debug,
+            LogLevel::Info,
         ))
         .await;
 


### PR DESCRIPTION
This PR upgrades the 

> [Task step 1 of 3]

message so that it's visible alongside the `2 of 3` and `3 of 3` messages with default settings..