### PR TITLE
Add script to measure peak memory usage

### DIFF
--- a/clients/cli/scripts/README.md
+++ b/clients/cli/scripts/README.md
@@ -80,4 +80,70 @@ The script will exit with an error if:
 - The build fails
 - The ELF file can't be copied
 
-All errors are displayed with red text and include helpful error messages. 
+All errors are displayed with red text and include helpful error messages.
+
+## Peak Memory Monitor Script
+
+The `peak_memory.sh` script monitors the peak memory usage of the nexus-cli during operation.
+
+### Usage
+
+```bash
+./scripts/peak_memory.sh [DURATION_SECONDS]
+```
+
+### Parameters
+
+- `DURATION_SECONDS` (optional): How long to monitor in seconds. Defaults to 60 seconds
+
+### Examples
+
+```bash
+# Monitor for default 60 seconds
+./scripts/peak_memory.sh
+
+# Monitor for 20 seconds
+./scripts/peak_memory.sh 20
+
+# Monitor for 5 minutes
+./scripts/peak_memory.sh 300
+```
+
+### What it does
+
+1. Starts `nexus-cli start --headless` in the background
+2. Monitors memory usage every second for the specified duration
+3. Tracks peak memory usage throughout the run
+4. Displays real-time current and peak memory usage
+5. Terminates the process and reports final statistics
+
+### Example Output
+
+```bash
+❯ ./scripts/peak_memory.sh 20
+Starting nexus-cli and monitoring memory for 20 seconds...
+[1/20s] Current: 4 MB, Peak: 4 MB
+[INFO!!!] ✅ Found Node ID from config file      Node ID: 19444429
+Refresh [2025-07-31 08:09:24] Task Fetcher: [Task step 1 of 3] Fetching task...
+[2/20s] Current: 241 MB, Peak: 241 MB
+[3/20s] Current: 795 MB, Peak: 795 MB
+[4/20s] Current: 1154 MB, Peak: 1154 MB
+[5/20s] Current: 1993 MB, Peak: 1993 MB
+[6/20s] Current: 2148 MB, Peak: 2148 MB
+[7/20s] Current: 1097 MB, Peak: 2148 MB
+...
+[13/20s] Current: 2970 MB, Peak: 2970 MB
+[14/20s] Current: 1714 MB, Peak: 2970 MB
+Success [2025-07-31 08:09:37] Prover 0: [Task step 2 of 3] Proof completed successfully
+[15/20s] Current: 642 MB, Peak: 2970 MB
+...
+[20/20s] Current: 643 MB, Peak: 2970 MB
+================================
+Peak Memory Usage: 2970 MB
+Total Runtime: 21 seconds
+================================
+```
+### Requirements
+
+- `nexus-cli` must be built and available in PATH or current directory
+- Valid nexus configuration (Node ID) for proper operation

--- a/clients/cli/scripts/peak_memory.sh
+++ b/clients/cli/scripts/peak_memory.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# This script measures the peak memory usage of the nexus-cli binary.
+# It starts the binary in headless mode and monitors the memory usage for specified seconds.
+# Usage: ./peak_memory.sh [SECONDS] (default: 60)
+
+DURATION=${1:-60}
+
+echo "Starting nexus-cli and monitoring memory for ${DURATION} seconds..."
+
+# Start the process in background and capture its PID
+nexus-cli start --headless &
+PID=$!
+
+# Record start time
+START_TIME=$(date +%s)
+
+# Monitor memory usage
+MAX_MEMORY=0
+for i in $(seq 1 $DURATION); do
+  if ps -p $PID > /dev/null 2>&1; then
+    MEMORY=$(ps -o rss= -p $PID 2>/dev/null | tr -d " ")
+    if [ "$MEMORY" ] && [ "$MEMORY" -gt "$MAX_MEMORY" ]; then
+      MAX_MEMORY=$MEMORY
+    fi
+    # Calculate MB for display
+    MAX_MEMORY_MB=$((MAX_MEMORY / 1024))
+    CURRENT_MEMORY_MB=$((MEMORY / 1024))
+    echo "[$i/${DURATION}s] Current: ${CURRENT_MEMORY_MB} MB, Peak: ${MAX_MEMORY_MB} MB"
+  else
+    echo "Process ended early at ${i}s"
+    break
+  fi
+  sleep 1
+done
+
+# Calculate total time
+END_TIME=$(date +%s)
+TOTAL_TIME=$((END_TIME - START_TIME))
+
+# Kill the process
+kill $PID 2>/dev/null
+wait $PID 2>/dev/null
+
+
+echo "================================"
+echo "Peak Memory Usage: ${MAX_MEMORY_MB} MB"
+echo "Total Runtime: ${TOTAL_TIME} seconds"
+echo "================================"


### PR DESCRIPTION

Summary:

```
❯ ./peak_memory.sh 20
Starting nexus-network and monitoring memory for 20 seconds...
[1/20s] Current: 4 MB, Peak: 4 MB
[INFO!!!] ✅ Found Node ID from config file      Node ID:
Refresh [2025-07-31 08:09:24] Task Fetcher: [Task step 1 of 3] Fetching task... Note: CLI tasks are harder to solve, so they receive more points than web provers
Refresh [2025-07-31 08:09:24] Task Fetcher: Queue status: +1 task → 1 total (1% full)
[2/20s] Current: 241 MB, Peak: 241 MB
[3/20s] Current: 795 MB, Peak: 795 MB
[4/20s] Current: 1154 MB, Peak: 1154 MB
[5/20s] Current: 1993 MB, Peak: 1993 MB
[6/20s] Current: 2148 MB, Peak: 2148 MB
[7/20s] Current: 1097 MB, Peak: 2148 MB
[8/20s] Current: 994 MB, Peak: 2148 MB
[9/20s] Current: 1366 MB, Peak: 2148 MB
[10/20s] Current: 1433 MB, Peak: 2148 MB
[11/20s] Current: 1945 MB, Peak: 2148 MB
[12/20s] Current: 2460 MB, Peak: 2460 MB
[13/20s] Current: 2970 MB, Peak: 2970 MB
[14/20s] Current: 1714 MB, Peak: 2970 MB
Success [2025-07-31 08:09:37] Prover 0: [Task step 2 of 3] Proof completed successfully (Task ID: 19444429-01K1G666SAWR0611SP2RWTQ0CV)
[15/20s] Current: 642 MB, Peak: 2970 MB
Error [2025-07-31 08:09:38] Proof Submitter: Failed to submit proof for task 19444429-01K1G666SAWR0611SP2RWTQ0CV. Status: 429, Message: {"name":"Error","message":"User's proof submission limit exceeded for user. Please try again later.","httpCode":429}
[16/20s] Current: 643 MB, Peak: 2970 MB
[17/20s] Current: 643 MB, Peak: 2970 MB
[18/20s] Current: 643 MB, Peak: 2970 MB
[19/20s] Current: 643 MB, Peak: 2970 MB
[20/20s] Current: 643 MB, Peak: 2970 MB
================================
Peak Memory Usage: 2970 MB
Total Runtime: 21 seconds
================================

```

Test Plan:
