### PR TITLE
headers["retry-after"] is empty and an error will occur

### DIFF
--- a/clients/cli/src/workers/online.rs
+++ b/clients/cli/src/workers/online.rs
@@ -433,18 +433,8 @@ async fn handle_fetch_error(
     match error {
         OrchestratorError::Http {
             status: 429,
-            ref headers,
             ..
         } => {
-            // Debug: print headers for 429 responses
-            send_event(
-                event_sender,
-                format!("429 Rate limit retry-after: {:?}", headers["retry-after"]),
-                crate::events::EventType::Refresh,
-                LogLevel::Debug,
-            )
-            .await;
-
             if let Some(retry_after_seconds) = error.get_retry_after_seconds() {
                 state.set_backoff_from_server(retry_after_seconds);
                 send_event(

--- a/clients/cli/src/workers/online.rs
+++ b/clients/cli/src/workers/online.rs
@@ -431,10 +431,7 @@ async fn handle_fetch_error(
     state: &mut TaskFetchState,
 ) {
     match error {
-        OrchestratorError::Http {
-            status: 429,
-            ..
-        } => {
+        OrchestratorError::Http { status: 429, .. } => {
             if let Some(retry_after_seconds) = error.get_retry_after_seconds() {
                 state.set_backoff_from_server(retry_after_seconds);
                 send_event(


### PR DESCRIPTION
The subsequent code has already checked whether headers["retry-after"] is empty or has a value and logged it. The logging here seems unnecessary and this code can be removed.

https://github.com/nexus-xyz/nexus-cli/blob/8aeba0087d93e0908175c017557e4aec8d32ecf4/clients/cli/src/workers/online.rs#L435-L454