### PR TITLE
fix: check retry-after without panicking

### DIFF
--- a/clients/cli/src/workers/online.rs
+++ b/clients/cli/src/workers/online.rs
@@ -439,7 +439,7 @@ async fn handle_fetch_error(
             // Debug: print headers for 429 responses
             send_event(
                 event_sender,
-                format!("429 Rate limit retry-after: {:?}", headers["retry-after"]),
+                format!("429 Rate limit retry-after: {:?}", headers.get("retry-after")),
                 crate::events::EventType::Refresh,
                 LogLevel::Debug,
             )

--- a/clients/cli/src/workers/online.rs
+++ b/clients/cli/src/workers/online.rs
@@ -439,7 +439,10 @@ async fn handle_fetch_error(
             // Debug: print headers for 429 responses
             send_event(
                 event_sender,
-                format!("429 Rate limit retry-after: {:?}", headers.get("retry-after")),
+                format!(
+                    "429 Rate limit retry-after: {:?}",
+                    headers.get("retry-after")
+                ),
                 crate::events::EventType::Refresh,
                 LogLevel::Debug,
             )


### PR DESCRIPTION
In the case that the server does not include a retry-after header upon receiving a 429 error, we should not panic. Instead, we should gracefully handle this case when logging.