### PR TITLE
feat: new task type that includes all the proof hashes for multi-input proof

### DIFF
--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -354,7 +354,8 @@ async fn start(
         {
             let shutdown_sender_clone2 = shutdown_sender.clone();
             tokio::spawn(async move {
-                if tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).is_ok() {
+                if tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).is_ok()
+                {
                     if let Ok(mut signal) =
                         tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
                     {

--- a/clients/cli/src/orchestrator/client.rs
+++ b/clients/cli/src/orchestrator/client.rs
@@ -295,6 +295,7 @@ impl Orchestrator for OrchestratorClient {
         signing_key: SigningKey,
         num_provers: usize,
         task_type: crate::nexus_orchestrator::TaskType,
+        individual_proof_hashes: &[String],
     ) -> Result<(), OrchestratorError> {
         let (program_memory, total_memory) = get_memory_info();
         let flops = estimate_peak_gflops(num_provers);
@@ -302,11 +303,27 @@ impl Orchestrator for OrchestratorClient {
 
         // Detect country for network optimization (privacy-preserving: only country code, no precise location)
         let location = self.get_country().await;
-        // Only attach proof if task type is not ProofHash
-        // If task_type is None, default to attaching proof for backward compatibility
-        let proof_to_send = match task_type {
-            crate::nexus_orchestrator::TaskType::ProofHash => Vec::new(),
-            _ => proof, // Attach proof for ProofRequired or None (backward compatibility)
+        // Handle different task types
+        let (proof_to_send, all_proof_hashes_to_send) = match task_type {
+            crate::nexus_orchestrator::TaskType::ProofHash => {
+                // For ProofHash tasks, don't send proof or individual hashes
+                (Vec::new(), Vec::new())
+            }
+            crate::nexus_orchestrator::TaskType::AllProofHashes => {
+                // For AllProofHashes tasks, don't send proof but send all individual hashes
+                // Add warning for large numbers of inputs
+                if individual_proof_hashes.len() > 100 {
+                    eprintln!(
+                        "WARNING: Task with {} individual proof hashes may not scale well for ALL_PROOF_HASHES task type",
+                        individual_proof_hashes.len()
+                    );
+                }
+                (Vec::new(), individual_proof_hashes.to_vec())
+            }
+            _ => {
+                // For ProofRequired and backward compatibility, attach proof
+                (proof, Vec::new())
+            }
         };
 
         let request = SubmitProofRequest {
@@ -323,7 +340,7 @@ impl Orchestrator for OrchestratorClient {
             }),
             ed25519_public_key: public_key,
             signature,
-            all_proof_hashes: Vec::new(),
+            all_proof_hashes: all_proof_hashes_to_send,
             proofs: Vec::new(),
         };
         let request_bytes = Self::encode_request(&request);
@@ -439,6 +456,7 @@ mod tests {
                 signing_key.clone(),
                 num_workers,
                 TaskType::ProofRequired,
+                &[], // No individual proof hashes for this test
             )
             .await;
         // This will fail because we're not actually submitting to a real orchestrator,
@@ -454,6 +472,7 @@ mod tests {
                 signing_key,
                 num_workers,
                 TaskType::ProofHash,
+                &[], // No individual proof hashes for this test
             )
             .await;
         // This will also fail, but the proof should be empty in the request

--- a/clients/cli/src/orchestrator/client.rs
+++ b/clients/cli/src/orchestrator/client.rs
@@ -323,6 +323,8 @@ impl Orchestrator for OrchestratorClient {
             }),
             ed25519_public_key: public_key,
             signature,
+            all_proof_hashes: Vec::new(),
+            proofs: Vec::new(),
         };
         let request_bytes = Self::encode_request(&request);
         self.post_request_no_response("v3/tasks/submit", request_bytes)

--- a/clients/cli/src/orchestrator/mod.rs
+++ b/clients/cli/src/orchestrator/mod.rs
@@ -39,6 +39,7 @@ pub trait Orchestrator: Send + Sync {
     ) -> Result<Task, OrchestratorError>;
 
     /// Submits a proof to the orchestrator.
+    #[allow(clippy::too_many_arguments)]
     async fn submit_proof(
         &self,
         task_id: &str,

--- a/clients/cli/src/orchestrator/mod.rs
+++ b/clients/cli/src/orchestrator/mod.rs
@@ -47,5 +47,6 @@ pub trait Orchestrator: Send + Sync {
         signing_key: SigningKey,
         num_provers: usize,
         task_type: crate::nexus_orchestrator::TaskType,
+        individual_proof_hashes: &[String],
     ) -> Result<(), OrchestratorError>;
 }

--- a/clients/cli/src/proto/nexus.orchestrator.rs
+++ b/clients/cli/src/proto/nexus.orchestrator.rs
@@ -79,16 +79,21 @@ pub struct GetProofTaskRequest {
 /// A Prover task.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetProofTaskResponse {
+    /// Deprecated: use field in Task instead.
     /// Program id. (Assuming client-side default programs)
+    #[deprecated]
     #[prost(string, tag = "1")]
     pub program_id: ::prost::alloc::string::String,
+    /// Deprecated: use field in Task instead.
     /// Public inputs to the program.
+    #[deprecated]
     #[prost(bytes = "vec", tag = "2")]
     pub public_inputs: ::prost::alloc::vec::Vec<u8>,
+    /// Deprecated: use field in Task instead.
     /// The task's ID.
+    #[deprecated]
     #[prost(string, tag = "3")]
     pub task_id: ::prost::alloc::string::String,
-    /// The task assigned.
     #[prost(message, optional, tag = "4")]
     pub task: ::core::option::Option<Task>,
 }
@@ -98,13 +103,13 @@ pub struct SubmitProofRequest {
     /// The type of this node.
     #[prost(enumeration = "NodeType", tag = "2")]
     pub node_type: i32,
-    /// Hash of the proof.
+    /// Hash of the concatenated proof bytes.
     #[prost(string, tag = "3")]
     pub proof_hash: ::prost::alloc::string::String,
     /// Telemetry data about the node
     #[prost(message, optional, tag = "4")]
     pub node_telemetry: ::core::option::Option<NodeTelemetry>,
-    /// ZK proof of the proof activity
+    /// ZK proof of the program and first set of inputs.
     #[prost(bytes = "vec", tag = "5")]
     pub proof: ::prost::alloc::vec::Vec<u8>,
     /// The task's ID.
@@ -120,6 +125,14 @@ pub struct SubmitProofRequest {
     /// corresponding to the public key.
     #[prost(bytes = "vec", tag = "8")]
     pub signature: ::prost::alloc::vec::Vec<u8>,
+    /// Hash of each individual proof.
+    /// Sent only on ALL_PROOF_HASHES task type.
+    #[prost(string, repeated, tag = "9")]
+    pub all_proof_hashes: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// ZK proofs of the program running on each set of inputs.
+    /// To be sent on PROOF_REQUIRED tasks only.
+    #[prost(bytes = "vec", repeated, tag = "10")]
+    pub proofs: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
 /// Performance stats of a node.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -235,8 +248,12 @@ impl TaskDifficulty {
 pub enum TaskType {
     /// Task requires a proof to be submitted
     ProofRequired = 0,
-    /// Task does not require a proof to be submitted
+    /// Task does not require a proof to be submitted.
+    /// All proof hashes should be hashed together.
     ProofHash = 1,
+    /// Task does not require a proof to be submitted,
+    /// but alll proof hashes should be sent.
+    AllProofHashes = 2,
 }
 impl TaskType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -247,6 +264,7 @@ impl TaskType {
         match self {
             Self::ProofRequired => "PROOF_REQUIRED",
             Self::ProofHash => "PROOF_HASH",
+            Self::AllProofHashes => "ALL_PROOF_HASHES",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -254,6 +272,7 @@ impl TaskType {
         match value {
             "PROOF_REQUIRED" => Some(Self::ProofRequired),
             "PROOF_HASH" => Some(Self::ProofHash),
+            "ALL_PROOF_HASHES" => Some(Self::AllProofHashes),
             _ => None,
         }
     }

--- a/clients/cli/src/proto/nexus.orchestrator.rs
+++ b/clients/cli/src/proto/nexus.orchestrator.rs
@@ -130,7 +130,7 @@ pub struct SubmitProofRequest {
     #[prost(string, repeated, tag = "9")]
     pub all_proof_hashes: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// ZK proofs of the program running on each set of inputs.
-    /// To be sent on PROOF_REQUIRED tasks only.
+    /// To be sent on PROOF_REQUIRED tasks, empty on other task types.
     #[prost(bytes = "vec", repeated, tag = "10")]
     pub proofs: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -317,11 +317,16 @@ mod tests {
         let client_id = "test_client".to_string();
 
         match authenticated_proving(&task, &environment, &client_id, None).await {
-            Ok((_proof, combined_hash)) => {
+            Ok((_proof, combined_hash, individual_hashes)) => {
                 // Should succeed with multiple inputs and return the first proof hash for ProofRequired
                 assert!(
                     !combined_hash.is_empty(),
                     "Expected proof hash for ProofRequired task type"
+                );
+                assert_eq!(
+                    individual_hashes.len(),
+                    2,
+                    "Expected 2 individual proof hashes for 2 inputs"
                 );
                 println!(
                     "Multiple inputs with ProofRequired works (returns first proof hash): {}",
@@ -356,11 +361,16 @@ mod tests {
         let client_id = "test_client".to_string();
 
         match authenticated_proving(&task, &environment, &client_id, None).await {
-            Ok((_proof, combined_hash)) => {
+            Ok((_proof, combined_hash, individual_hashes)) => {
                 // Should have a combined hash for multiple inputs
                 assert!(
                     !combined_hash.is_empty(),
                     "Expected combined hash for multiple inputs"
+                );
+                assert_eq!(
+                    individual_hashes.len(),
+                    2,
+                    "Expected 2 individual proof hashes for 2 inputs"
                 );
                 println!("Combined hash: {}", combined_hash);
             }
@@ -385,11 +395,16 @@ mod tests {
         let client_id = "test_client".to_string();
 
         match authenticated_proving(&task, &environment, &client_id, None).await {
-            Ok((_proof, combined_hash)) => {
+            Ok((_proof, combined_hash, individual_hashes)) => {
                 // Should have combined hash for ProofHash task type, even with single input
                 assert!(
                     !combined_hash.is_empty(),
                     "Expected combined hash for ProofHash task type"
+                );
+                assert_eq!(
+                    individual_hashes.len(),
+                    1,
+                    "Expected 1 individual proof hash for 1 input"
                 );
                 println!(
                     "Single input with ProofHash - combined hash: {}",
@@ -419,7 +434,7 @@ mod tests {
         let client_id = "test_client".to_string();
 
         match authenticated_proving(&task, &environment, &client_id, None).await {
-            Ok((_proof, combined_hash)) => {
+            Ok((_proof, combined_hash, individual_hashes)) => {
                 // Should have proof hash for single input with ProofRequired
                 assert!(
                     !combined_hash.is_empty(),
@@ -535,7 +550,7 @@ mod tests {
         let (event_sender, mut event_receiver) = tokio::sync::mpsc::channel::<WorkerEvent>(10);
 
         match authenticated_proving(&task, &environment, &client_id, Some(&event_sender)).await {
-            Ok((_proof, combined_hash)) => {
+            Ok((_proof, combined_hash, individual_hashes)) => {
                 // Should have combined hash for multiple inputs with ProofHash
                 assert!(
                     !combined_hash.is_empty(),

--- a/clients/cli/src/prover.rs
+++ b/clients/cli/src/prover.rs
@@ -440,6 +440,11 @@ mod tests {
                     !combined_hash.is_empty(),
                     "Expected proof hash for single input with ProofRequired"
                 );
+                assert_eq!(
+                    individual_hashes.len(),
+                    1,
+                    "Expected exactly 1 individual proof hash for single input"
+                );
                 println!(
                     "Single input with ProofRequired - returns proof hash: {}",
                     combined_hash
@@ -555,6 +560,11 @@ mod tests {
                 assert!(
                     !combined_hash.is_empty(),
                     "Expected combined hash for ProofHash task type"
+                );
+                assert_eq!(
+                    individual_hashes.len(),
+                    2,
+                    "Expected exactly 2 individual proof hashes for 2 inputs"
                 );
 
                 // Check that progress events were sent

--- a/clients/cli/src/task.rs
+++ b/clients/cli/src/task.rs
@@ -93,16 +93,15 @@ impl From<&crate::nexus_orchestrator::Task> for Task {
 // From GetProofTaskResponse
 impl From<&crate::nexus_orchestrator::GetProofTaskResponse> for Task {
     fn from(response: &crate::nexus_orchestrator::GetProofTaskResponse) -> Self {
-        let task_type = crate::nexus_orchestrator::TaskType::try_from(
-            response.task.as_ref().unwrap().task_type,
-        )
-        .unwrap();
+        let task = response.task.as_ref().expect("Task field is required");
+        let task_type = crate::nexus_orchestrator::TaskType::try_from(task.task_type)
+            .expect("Invalid task type");
 
         Task {
-            task_id: response.task_id.clone(),
-            program_id: response.program_id.clone(),
-            public_inputs: response.public_inputs.clone(),
-            public_inputs_list: vec![response.public_inputs.clone()],
+            task_id: task.task_id.clone(),
+            program_id: task.program_id.clone(),
+            public_inputs: task.public_inputs_list.first().cloned().unwrap_or_default(),
+            public_inputs_list: task.public_inputs_list.clone(),
             task_type,
         }
     }

--- a/clients/cli/src/version_checker.rs
+++ b/clients/cli/src/version_checker.rs
@@ -485,11 +485,16 @@ mod tests {
         while let Ok(event) = event_receiver.try_recv() {
             if matches!(event.worker, Worker::VersionChecker) {
                 received_event = true;
-                // With current version 0.9.0, we expect a warning constraint message
+                // Check for either constraint-based message or fallback update message
+                // Both indicate version issues that users should act on
+                let is_constraint_message = event.msg.contains("does not meet the minimum required version") ||
+                                          event.msg.contains("Please upgrade");
+                let is_update_message = event.msg.contains("New version") && event.msg.contains("available");
+                
                 assert!(
-                    event
-                        .msg
-                        .contains("Consider upgrading for the best experience")
+                    is_constraint_message || is_update_message,
+                    "Version checker should send either a constraint violation or update available message, got: {}",
+                    event.msg
                 );
                 break;
             }

--- a/clients/cli/src/workers/offline.rs
+++ b/clients/cli/src/workers/offline.rs
@@ -92,7 +92,7 @@ pub fn start_workers(
                             .send(Event::prover(worker_id, message, EventType::Success))
                             .await;
                         match authenticated_proving(&task, &environment, &client_id, Some(&prover_event_sender)).await {
-                            Ok((proof, combined_hash)) => {
+                            Ok((proof, combined_hash, individual_proof_hashes)) => {
 
                                 // Track analytics for successful proof (non-blocking)
                                 tokio::spawn(track_authenticated_proof_analytics(task.clone(), environment.clone(), client_id.clone()));
@@ -101,6 +101,7 @@ pub fn start_workers(
                                 let proof_result = ProofResult {
                                     proof,
                                     combined_hash,
+                                    individual_proof_hashes,
                                 };
                                 let _ = results_sender.send((task, proof_result)).await;
                             }

--- a/clients/cli/src/workers/online.rs
+++ b/clients/cli/src/workers/online.rs
@@ -30,6 +30,7 @@ use tokio::task::JoinHandle;
 pub struct ProofResult {
     pub proof: Proof,
     pub combined_hash: String,
+    pub individual_proof_hashes: Vec<String>,
 }
 
 /// Helper to send events with consistent error handling
@@ -425,6 +426,7 @@ pub async fn submit_proofs(
                                 task,
                                 proof_result.proof,
                                 proof_result.combined_hash,
+                                proof_result.individual_proof_hashes,
                                 &*orchestrator,
                                 &signing_key,
                                 num_workers,
@@ -559,6 +561,7 @@ async fn process_proof_submission(
     task: Task,
     proof: Proof,
     combined_hash: String,
+    individual_proof_hashes: Vec<String>,
     orchestrator: &dyn Orchestrator,
     signing_key: &SigningKey,
     num_workers: usize,

--- a/clients/cli/src/workers/online.rs
+++ b/clients/cli/src/workers/online.rs
@@ -495,6 +495,7 @@ async fn submit_proof_to_orchestrator(
     task: &Task,
     proof: &Proof,
     proof_hash: &str,
+    individual_proof_hashes: &[String],
     orchestrator: &dyn Orchestrator,
     signing_key: &SigningKey,
     num_workers: usize,
@@ -525,6 +526,7 @@ async fn submit_proof_to_orchestrator(
             signing_key.clone(),
             num_workers,
             task.task_type,
+            individual_proof_hashes,
         )
         .await
     {
@@ -584,6 +586,7 @@ async fn process_proof_submission(
         &task,
         &proof,
         &proof_hash,
+        &individual_proof_hashes,
         orchestrator,
         signing_key,
         num_workers,

--- a/proto/orchestrator.proto
+++ b/proto/orchestrator.proto
@@ -104,13 +104,14 @@ message SubmitProofRequest {
   // The type of this node.
   NodeType node_type = 2;
 
-  // Hash of the proof.
-  string proof_hash = 3;
+  // Hash of the concatenated proof bytes.
+  // Not sent for PROOF_REQUIRED task type.
+  optional string proof_hash = 3;
 
   // Telemetry data about the node
   NodeTelemetry node_telemetry = 4;
 
-  // ZK proof of the proof activity
+  // ZK proof of the program and first set of inputs.
   bytes proof = 5;
 
   // The task's ID.
@@ -125,6 +126,14 @@ message SubmitProofRequest {
   // task_id + hash(proof) with the Ed25519 private key
   // corresponding to the public key.
   bytes signature = 8;
+
+  // Hash of each individual proof.
+  // Sent only on ALL_PROOF_HASHES task type.
+  repeated string all_proof_hashes = 9;
+
+  // ZK proofs of the program running on each set of inputs.
+  // To be sent on PROOF_REQUIRED tasks only.
+  optional repeated bytes proofs = 10;
 }
 
 // Performance stats of a node.
@@ -169,8 +178,13 @@ enum TaskType {
   // Task requires a proof to be submitted
   PROOF_REQUIRED = 0;
   
-  // Task does not require a proof to be submitted
+  // Task does not require a proof to be submitted.
+  // All proof hashes should be hashed together.
   PROOF_HASH = 1;
+
+  // Task does not require a proof to be submitted,
+  // but alll proof hashes should be sent.
+  ALL_PROOF_HASHES = 2;
 }
 
 // Response to get a single node by ID

--- a/proto/orchestrator.proto
+++ b/proto/orchestrator.proto
@@ -105,8 +105,7 @@ message SubmitProofRequest {
   NodeType node_type = 2;
 
   // Hash of the concatenated proof bytes.
-  // Not sent for PROOF_REQUIRED task type.
-  optional string proof_hash = 3;
+  string proof_hash = 3;
 
   // Telemetry data about the node
   NodeTelemetry node_telemetry = 4;
@@ -132,8 +131,8 @@ message SubmitProofRequest {
   repeated string all_proof_hashes = 9;
 
   // ZK proofs of the program running on each set of inputs.
-  // To be sent on PROOF_REQUIRED tasks only.
-  optional repeated bytes proofs = 10;
+  // To be sent on PROOF_REQUIRED tasks, empty on other task types.
+  repeated bytes proofs = 10;
 }
 
 // Performance stats of a node.


### PR DESCRIPTION
Handle a new task type that includes all the proof hashes instead of just a combined one.

This is to give the server more insight into why clients are submitting invalid proofs.