### PR TITLE
feat: subprocess proving

### DIFF
--- a/clients/cli/src/analytics.rs
+++ b/clients/cli/src/analytics.rs
@@ -29,22 +29,6 @@ pub enum TrackError {
     },
 }
 
-/// Track analytics for likely OOM error in proof subprocess (non-blocking)
-pub async fn track_likely_oom_error(environment: Environment, client_id: String) {
-    let analytics_data = json!({});
-    let _ = track(
-        vec![
-            "cli_likely_oom_error".to_string(),
-            "likely_oom_error".to_string(),
-        ],
-        analytics_data,
-        &environment,
-        client_id,
-    )
-    .await;
-    // TODO: Catch errors and log them
-}
-
 pub const PRODUCTION_MEASUREMENT_ID: &str = "G-GLH0GMEEFH";
 pub const PRODUCTION_API_SECRET: &str = "3wxu8FjVSPqOlxSsZEnBOw";
 
@@ -343,6 +327,26 @@ pub async fn track_authenticated_proof_analytics(
 
     let _ = track(
         vec!["cli_proof_node_v4".to_string(), "proof_node".to_string()],
+        analytics_data,
+        &environment,
+        client_id,
+    )
+    .await;
+    // TODO: Catch errors and log them
+}
+
+/// Track analytics for likely OOM error in proof subprocess (non-blocking)
+pub async fn track_likely_oom_error(task: Task, environment: Environment, client_id: String) {
+    let analytics_data = json!({
+        "program_name": task.program_id,
+        "task_id": task.task_id,
+    });
+
+    let _ = track(
+        vec![
+            "cli_likely_oom_error".to_string(),
+            "likely_oom_error".to_string(),
+        ],
         analytics_data,
         &environment,
         client_id,

--- a/clients/cli/src/analytics.rs
+++ b/clients/cli/src/analytics.rs
@@ -29,6 +29,22 @@ pub enum TrackError {
     },
 }
 
+/// Track analytics for likely OOM error in proof subprocess (non-blocking)
+pub async fn track_likely_oom_error(environment: Environment, client_id: String) {
+    let analytics_data = json!({});
+    let _ = track(
+        vec![
+            "cli_likely_oom_error".to_string(),
+            "likely_oom_error".to_string(),
+        ],
+        analytics_data,
+        &environment,
+        client_id,
+    )
+    .await;
+    // TODO: Catch errors and log them
+}
+
 pub const PRODUCTION_MEASUREMENT_ID: &str = "G-GLH0GMEEFH";
 pub const PRODUCTION_API_SECRET: &str = "3wxu8FjVSPqOlxSsZEnBOw";
 

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -25,16 +25,16 @@ mod workers;
 use crate::config::{Config, get_config_path};
 use crate::environment::Environment;
 use crate::orchestrator::OrchestratorClient;
+use crate::prover::engine::ProvingEngine;
 use crate::register::{register_node, register_user};
 use crate::session::{run_headless_mode, run_tui_mode, setup_session};
 use crate::version::manager::validate_version_requirements;
 use clap::{ArgAction, Parser, Subcommand};
+use postcard::to_allocvec;
+use serde_json;
 use std::error::Error;
 use std::io::Write;
 use std::process::exit;
-use postcard::to_allocvec;
-use serde_json;
-use crate::prover::engine::ProvingEngine;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]

--- a/clients/cli/src/prover/engine.rs
+++ b/clients/cli/src/prover/engine.rs
@@ -5,16 +5,15 @@ use crate::prover::verifier;
 use super::types::ProverError;
 use crate::analytics::track_likely_oom_error;
 use crate::environment::Environment;
+use crate::task::Task;
 use nexus_sdk::{
     Local, Prover,
     stwo::seq::{Proof, Stwo},
 };
-use postcard::{from_bytes, to_allocvec};
+use postcard::from_bytes;
 use serde_json;
 use std::env;
 use std::process::Stdio;
-use tokio::process::Command;
-use tokio::spawn;
 
 /// Core proving engine for ZK proof generation
 pub struct ProvingEngine;
@@ -57,7 +56,7 @@ impl ProvingEngine {
     ) -> Result<Proof, ProverError> {
         // Spawn a subprocess for proof generation to isolate memory usage
         let exe_path = env::current_exe()?;
-        let mut cmd = Command::new(exe_path);
+        let mut cmd = tokio::process::Command::new(exe_path);
         cmd.arg("prove-fib-subprocess")
             .arg("--inputs")
             .arg(serde_json::to_string(inputs)?)

--- a/clients/cli/src/prover/engine.rs
+++ b/clients/cli/src/prover/engine.rs
@@ -7,11 +7,16 @@ use nexus_sdk::{
     Local, Prover,
     stwo::seq::{Proof, Stwo},
 };
+use tokio::process::Command;
+use std::process::Stdio;
+use std::env;
+use postcard::{from_bytes, to_allocvec};
+use serde_json;
 
 /// Core proving engine for ZK proof generation
-pub struct ProvingEngine;
+    pub struct ProvingEngine;
 
-impl ProvingEngine {
+    impl ProvingEngine {
     /// Create a Stwo prover instance for the fibonacci program
     pub fn create_fib_prover() -> Result<Stwo<Local>, ProverError> {
         let elf_bytes = include_bytes!("../../assets/fib_input_initial");
@@ -23,9 +28,8 @@ impl ProvingEngine {
         })
     }
 
-    /// Generate proof for given inputs using the fibonacci program
-    /// Returns the proof and a validation function for the view
-    pub fn prove_and_validate(inputs: &(u32, u32, u32)) -> Result<Proof, ProverError> {
+    /// Subprocess entrypoint: generate proof without verification
+    pub fn prove_fib_subprocess(inputs: &(u32, u32, u32)) -> Result<Proof, ProverError> {
         let prover = Self::create_fib_prover()?;
         let (view, proof) = prover
             .prove_with_input::<(), (u32, u32, u32)>(&(), inputs)
@@ -35,10 +39,35 @@ impl ProvingEngine {
                     inputs, e
                 ))
             })?;
-
+        // Check exit code in subprocess
         verifier::ProofVerifier::check_exit_code(&view)?;
 
-        // Verify proof immediately (create fresh prover for verification)
+        Ok(proof)
+    }
+
+    /// Generate proof for given inputs using the fibonacci program in a subprocess
+    pub async fn prove_and_validate(inputs: &(u32, u32, u32)) -> Result<Proof, ProverError> {
+        // Spawn a subprocess for proof generation to isolate memory usage
+        let exe_path = env::current_exe()?;
+        let mut cmd = Command::new(exe_path);
+        cmd.arg("prove-fib-subprocess")
+            .arg("--inputs")
+            .arg(serde_json::to_string(inputs)?)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+
+        let output = cmd.output().await?;
+        if !output.status.success() {
+            return Err(ProverError::Subprocess(format!(
+                "Prover subprocess failed with status: {}",
+                output.status
+            )));
+        }
+
+        // Deserialize proof from subprocess stdout
+        let proof: Proof = from_bytes(&output.stdout)?;
+
+        // Verify proof in main process
         let verify_prover = Self::create_fib_prover()?;
         verifier::ProofVerifier::verify_proof(&proof, inputs, &verify_prover)?;
 

--- a/clients/cli/src/prover/pipeline.rs
+++ b/clients/cli/src/prover/pipeline.rs
@@ -50,17 +50,19 @@ impl ProvingPipeline {
             let inputs = InputParser::parse_triple_input(input_data)?;
 
             // Step 2: Generate and verify proof
-            let proof = ProvingEngine::prove_and_validate(&inputs).await.map_err(|e| {
-                // Track verification failure
-                let error_msg = format!("Input {}: {}", input_index, e);
-                tokio::spawn(track_verification_failed(
-                    task.clone(),
-                    error_msg.clone(),
-                    environment.clone(),
-                    client_id.to_string(),
-                ));
-                e
-            })?;
+            let proof = ProvingEngine::prove_and_validate(&inputs, environment, client_id)
+                .await
+                .map_err(|e| {
+                    // Track verification failure
+                    let error_msg = format!("Input {}: {}", input_index, e);
+                    tokio::spawn(track_verification_failed(
+                        task.clone(),
+                        error_msg.clone(),
+                        environment.clone(),
+                        client_id.to_string(),
+                    ));
+                    e
+                })?;
 
             // Step 3: Generate proof hash
             let proof_hash = Self::generate_proof_hash(&proof);

--- a/clients/cli/src/prover/pipeline.rs
+++ b/clients/cli/src/prover/pipeline.rs
@@ -54,7 +54,7 @@ impl ProvingPipeline {
                 .await
                 .map_err(|e| {
                     match e {
-                        ProverError::Stwo | ProverError::GuestProgram => {
+                        ProverError::Stwo(_) | ProverError::GuestProgram(_) => {
                             // Track verification failure
                             let error_msg = format!("Input {}: {}", input_index, e);
                             tokio::spawn(track_verification_failed(

--- a/clients/cli/src/prover/pipeline.rs
+++ b/clients/cli/src/prover/pipeline.rs
@@ -50,7 +50,7 @@ impl ProvingPipeline {
             let inputs = InputParser::parse_triple_input(input_data)?;
 
             // Step 2: Generate and verify proof
-            let proof = ProvingEngine::prove_and_validate(&inputs).map_err(|e| {
+            let proof = ProvingEngine::prove_and_validate(&inputs).await.map_err(|e| {
                 // Track verification failure
                 let error_msg = format!("Input {}: {}", input_index, e);
                 tokio::spawn(track_verification_failed(

--- a/clients/cli/src/prover/pipeline.rs
+++ b/clients/cli/src/prover/pipeline.rs
@@ -50,7 +50,7 @@ impl ProvingPipeline {
             let inputs = InputParser::parse_triple_input(input_data)?;
 
             // Step 2: Generate and verify proof
-            let proof = ProvingEngine::prove_and_validate(&inputs, environment, client_id)
+            let proof = ProvingEngine::prove_and_validate(&inputs, task, environment, client_id)
                 .await
                 .map_err(|e| {
                     // Track verification failure

--- a/clients/cli/src/prover/types.rs
+++ b/clients/cli/src/prover/types.rs
@@ -16,6 +16,15 @@ pub enum ProverError {
 
     #[error("Guest Program error: {0}")]
     GuestProgram(String),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Subprocess error: {0}")]
+    Subprocess(String),
+
+    #[error("Serde JSON error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
 }
 
 /// Result of a proof generation, including combined hash for multiple inputs


### PR DESCRIPTION
This PR changes the proving to invoke itself as a subprocess, rather than just calling the zkVM directly. Importantly, this means that if the kernel kills the proving process, such as due to an OOM, it can be caught and gracefully handled by the CLI rather than causing the entire process to be killed.

The PR also adds functionality to check the status code in event of an error, and if it is a 137 (corresponding to an external SIGKILL, which is most often due to an OOM error), the CLI will then send an analytics event to allow us to track such issues.