### PR TITLE
feat: warn on risk of memory errors (gated by flag)

### DIFF
--- a/clients/cli/src/cli_messages.rs
+++ b/clients/cli/src/cli_messages.rs
@@ -13,6 +13,16 @@ pub fn print_info(title: &str, details: &str) {
     }
 }
 
+/// Print CLI command warn message
+pub fn print_warn(title: &str, details: &str) {
+    print!("\x1b[1;91m[WARN]\x1b[0m {}", title);
+    if !details.is_empty() {
+        println!("\t {}", details);
+    } else {
+        println!();
+    }
+}
+
 /// Print CLI command error
 pub fn print_error(title: &str, details: Option<&str>) {
     println!("\x1b[1;31m[ERROR]\x1b[0m {}", title);
@@ -36,6 +46,14 @@ pub fn print_success(title: &str, details: &str) {
 macro_rules! print_cmd_info {
     ($title:expr, $($details:tt)*) => {
         $crate::cli_messages::print_info($title, &format!($($details)*))
+    };
+}
+
+/// Macro for print_cmd_warn! usage
+#[macro_export]
+macro_rules! print_cmd_warn {
+    ($title:expr, $($details:tt)*) => {
+        $crate::cli_messages::print_warn($title, &format!($($details)*))
     };
 }
 

--- a/clients/cli/src/consts.rs
+++ b/clients/cli/src/consts.rs
@@ -13,11 +13,18 @@ pub mod cli_consts {
     /// Maximum number of events that can be queued for UI updates
     pub const EVENT_QUEUE_SIZE: usize = 100;
 
+    // =============================================================================
+    // PROVING CONFIGURATIONS
+    // =============================================================================
+
     /// Subprocess error code likely indicating an OOM error
     pub const SUBPROCESS_SUSPECTED_OOM_CODE: i32 = 137;
 
     /// Subprocess error code indicating an internal failure of the proving
     pub const SUBPROCESS_INTERNAL_ERROR_CODE: i32 = 3;
+
+    /// "Reasonable" generic projection task memory requirement.
+    pub const PROJECTED_MEMORY_REQUIREMENT: u64 = 4294967296; // 4gb
 
     // =============================================================================
     // NETWORK CONFIGURATION

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -64,6 +64,10 @@ enum Command {
         #[arg(long = "orchestrator-url", value_name = "URL")]
         orchestrator_url: Option<String>,
 
+        /// Enable checking for risk of memory errors, may slow down CLI startup
+        #[arg(long = "check-memory", default_value_t = false)]
+        check_mem: bool,
+
         /// Enable background colors in the dashboard
         #[arg(long = "with-background", action = ArgAction::SetTrue)]
         with_background: bool,
@@ -117,6 +121,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             headless,
             max_threads,
             orchestrator_url,
+            check_mem,
             with_background,
             max_tasks,
         } => {
@@ -134,6 +139,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 config_path,
                 headless,
                 max_threads,
+                check_mem,
                 with_background,
                 max_tasks,
             )
@@ -184,6 +190,7 @@ async fn start(
     config_path: std::path::PathBuf,
     headless: bool,
     max_threads: Option<u32>,
+    check_mem: bool,
     with_background: bool,
     max_tasks: Option<u32>,
 ) -> Result<(), Box<dyn Error>> {
@@ -195,7 +202,7 @@ async fn start(
     let config = Config::resolve(node_id, &config_path, &orchestrator_client).await?;
 
     // 3. Session setup (authenticated worker only)
-    let session = setup_session(config, env, max_threads, max_tasks).await?;
+    let session = setup_session(config, env, check_mem, max_threads, max_tasks).await?;
 
     // 4. Run appropriate mode
     if headless {


### PR DESCRIPTION
This PR adds a check to the CLI startup process to see whether `max-threads * 4gb >= process.memory`. If so, it warns the user they may have requested too much work for their machine, and therefore are at risk of an OOM error.

The check needs to warn the user, and so pauses the setup process for a few seconds in order for this to be visible before it gets buried in a run of other message. As such, the check is gated behind a flag. The idea here is that if a user complains about OOM issues, support can ask them to run `nexus-cli start --check-memory` and see whether they get a warning, as part of the debugging process.