### PR TITLE
chore: recommend 0.10.8

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -6,9 +6,9 @@
       "message": "Your version {current} does not meet the minimum required version {version}. Please upgrade to continue proving. Visit https://github.com/nexus-xyz/nexus-cli/releases for the latest version."
     },
     {
-      "version": "0.10.7",
+      "version": "0.10.8",
       "type": "warning",
-      "message": "Your version {current} is older than the recommended version {version}. Consider upgrading for the best experience."
+      "message": "Your version {current} is older than the recommended version {version}. Consider upgrading to unlock additional proving tasks."
     }
   ]
 } 


### PR DESCRIPTION
Update version.json to recommend 0.10.8
This doesn't require a release.