### PR TITLE
feat: support multi-process parallel proof

### DIFF
--- a/clients/cli/Cargo.lock
+++ b/clients/cli/Cargo.lock
@@ -962,12 +962,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -975,6 +991,40 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -988,10 +1038,16 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1630,6 +1686,7 @@ dependencies = [
  "clap",
  "crossterm 0.29.0",
  "ed25519-dalek",
+ "futures",
  "home",
  "iana-time-zone",
  "log",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -63,6 +63,7 @@ tokio = { version = "1.38", features = ["full"] }
 urlencoding = "2.1.3"
 uuid = "1.16.0"
 semver = "1.0"
+futures = "0.3.31"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/clients/cli/src/prover/handlers.rs
+++ b/clients/cli/src/prover/handlers.rs
@@ -11,6 +11,7 @@ pub async fn authenticated_proving(
     task: &Task,
     environment: &Environment,
     client_id: &str,
+    num_workers: &usize,
 ) -> Result<(Vec<Proof>, String, Vec<String>), ProverError> {
-    ProvingPipeline::prove_authenticated(task, environment, client_id).await
+    ProvingPipeline::prove_authenticated(task, environment, client_id, num_workers).await
 }

--- a/clients/cli/src/prover/pipeline.rs
+++ b/clients/cli/src/prover/pipeline.rs
@@ -8,6 +8,7 @@ use crate::environment::Environment;
 use crate::task::Task;
 use nexus_sdk::stwo::seq::Proof;
 use sha3::{Digest, Keccak256};
+use futures::stream::{StreamExt,TryStreamExt};
 
 /// Orchestrates the complete proving pipeline
 pub struct ProvingPipeline;
@@ -18,9 +19,10 @@ impl ProvingPipeline {
         task: &Task,
         environment: &Environment,
         client_id: &str,
+        num_workers: &usize,
     ) -> Result<(Vec<Proof>, String, Vec<String>), ProverError> {
         match task.program_id.as_str() {
-            "fib_input_initial" => Self::prove_fib_task(task, environment, client_id).await,
+            "fib_input_initial" => Self::prove_fib_task(task, environment, client_id, num_workers).await,
             _ => Err(ProverError::MalformedTask(format!(
                 "Unsupported program ID: {}",
                 task.program_id
@@ -33,6 +35,7 @@ impl ProvingPipeline {
         task: &Task,
         environment: &Environment,
         client_id: &str,
+        num_workers: &usize,
     ) -> Result<(Vec<Proof>, String, Vec<String>), ProverError> {
         let all_inputs = task.all_inputs();
 
@@ -44,38 +47,56 @@ impl ProvingPipeline {
 
         let mut proof_hashes = Vec::new();
         let mut all_proofs: Vec<Proof> = Vec::new();
+        
+        let all_inputs: Vec<Vec<u8>> = all_inputs.iter().cloned().collect();
 
-        for (input_index, input_data) in all_inputs.iter().enumerate() {
-            // Step 1: Parse and validate input
-            let inputs = InputParser::parse_triple_input(input_data)?;
+        let stream = futures::stream::iter(all_inputs.into_iter().enumerate().map(|(input_index, input_data)| {
+            async move {
+                // Step 1: Parse and validate input
+                let inputs = InputParser::parse_triple_input(&input_data)?;
 
-            // Step 2: Generate and verify proof
-            let proof = ProvingEngine::prove_and_validate(&inputs, task, environment, client_id)
-                .await
-                .map_err(|e| {
-                    match e {
-                        ProverError::Stwo(_) | ProverError::GuestProgram(_) => {
-                            // Track verification failure
-                            let error_msg = format!("Input {}: {}", input_index, e);
-                            tokio::spawn(track_verification_failed(
-                                task.clone(),
-                                error_msg.clone(),
-                                environment.clone(),
-                                client_id.to_string(),
-                            ));
-                            e
+                // Step 2: Generate and verify proof
+                let proof = ProvingEngine::prove_and_validate(&inputs, &task, &environment, &client_id)
+                    .await
+                    .map_err(|e| {
+                        match e {
+                            ProverError::Stwo(_) | ProverError::GuestProgram(_) => {
+                                // Track verification failure
+                                let error_msg = format!("Input {}: {}", input_index, e);
+                                tokio::spawn(track_verification_failed(
+                                    task.clone(),
+                                    error_msg.clone(),
+                                    environment.clone(),
+                                    client_id.to_string(),
+                                ));
+                                e
+                            }
+                            _ => e,
                         }
-                        _ => e,
-                    }
-                })?;
+                    })?;
 
-            // Step 3: Generate proof hash
-            let proof_hash = Self::generate_proof_hash(&proof);
-            proof_hashes.push(proof_hash);
+                // Step 3: Generate proof hash
+                let proof_hash = Self::generate_proof_hash(&proof);
+                Ok::<(Proof, String, usize), ProverError>((proof, proof_hash, input_index))
+            }
+        }));
+
+        let results: Vec<(Proof, String, usize)> = match stream.buffer_unordered(num_workers.clone()).try_collect().await {
+            Ok(res) => res,
+            Err(e) => {
+                return Err(e);
+            }
+        };
+        
+        let mut results = results;
+        results.sort_by_key(|(_, _, index)| *index);
+
+        for (proof, hash, _) in results {
+            proof_hashes.push(hash);
             all_proofs.push(proof);
         }
 
-        let final_proof_hash = Self::combine_proof_hashes(task, &proof_hashes);
+        let final_proof_hash = Self::combine_proof_hashes(&task, &proof_hashes);
 
         Ok((all_proofs, final_proof_hash, proof_hashes))
     }

--- a/clients/cli/src/prover/pipeline.rs
+++ b/clients/cli/src/prover/pipeline.rs
@@ -6,9 +6,9 @@ use super::types::ProverError;
 use crate::analytics::track_verification_failed;
 use crate::environment::Environment;
 use crate::task::Task;
+use futures::stream::{StreamExt, TryStreamExt};
 use nexus_sdk::stwo::seq::Proof;
 use sha3::{Digest, Keccak256};
-use futures::stream::{StreamExt,TryStreamExt};
 
 /// Orchestrates the complete proving pipeline
 pub struct ProvingPipeline;
@@ -22,7 +22,9 @@ impl ProvingPipeline {
         num_workers: &usize,
     ) -> Result<(Vec<Proof>, String, Vec<String>), ProverError> {
         match task.program_id.as_str() {
-            "fib_input_initial" => Self::prove_fib_task(task, environment, client_id, num_workers).await,
+            "fib_input_initial" => {
+                Self::prove_fib_task(task, environment, client_id, num_workers).await
+            }
             _ => Err(ProverError::MalformedTask(format!(
                 "Unsupported program ID: {}",
                 task.program_id
@@ -47,47 +49,54 @@ impl ProvingPipeline {
 
         let mut proof_hashes = Vec::new();
         let mut all_proofs: Vec<Proof> = Vec::new();
-        
+
         let all_inputs: Vec<Vec<u8>> = all_inputs.iter().cloned().collect();
 
-        let stream = futures::stream::iter(all_inputs.into_iter().enumerate().map(|(input_index, input_data)| {
-            async move {
-                // Step 1: Parse and validate input
-                let inputs = InputParser::parse_triple_input(&input_data)?;
+        let stream = futures::stream::iter(all_inputs.into_iter().enumerate().map(
+            |(input_index, input_data)| {
+                async move {
+                    // Step 1: Parse and validate input
+                    let inputs = InputParser::parse_triple_input(&input_data)?;
 
-                // Step 2: Generate and verify proof
-                let proof = ProvingEngine::prove_and_validate(&inputs, &task, &environment, &client_id)
-                    .await
-                    .map_err(|e| {
-                        match e {
-                            ProverError::Stwo(_) | ProverError::GuestProgram(_) => {
-                                // Track verification failure
-                                let error_msg = format!("Input {}: {}", input_index, e);
-                                tokio::spawn(track_verification_failed(
-                                    task.clone(),
-                                    error_msg.clone(),
-                                    environment.clone(),
-                                    client_id.to_string(),
-                                ));
-                                e
-                            }
-                            _ => e,
-                        }
-                    })?;
+                    // Step 2: Generate and verify proof
+                    let proof =
+                        ProvingEngine::prove_and_validate(&inputs, &task, &environment, &client_id)
+                            .await
+                            .map_err(|e| {
+                                match e {
+                                    ProverError::Stwo(_) | ProverError::GuestProgram(_) => {
+                                        // Track verification failure
+                                        let error_msg = format!("Input {}: {}", input_index, e);
+                                        tokio::spawn(track_verification_failed(
+                                            task.clone(),
+                                            error_msg.clone(),
+                                            environment.clone(),
+                                            client_id.to_string(),
+                                        ));
+                                        e
+                                    }
+                                    _ => e,
+                                }
+                            })?;
 
-                // Step 3: Generate proof hash
-                let proof_hash = Self::generate_proof_hash(&proof);
-                Ok::<(Proof, String, usize), ProverError>((proof, proof_hash, input_index))
-            }
-        }));
+                    // Step 3: Generate proof hash
+                    let proof_hash = Self::generate_proof_hash(&proof);
+                    Ok::<(Proof, String, usize), ProverError>((proof, proof_hash, input_index))
+                }
+            },
+        ));
 
-        let results: Vec<(Proof, String, usize)> = match stream.buffer_unordered(num_workers.clone()).try_collect().await {
+        let results: Vec<(Proof, String, usize)> = match stream
+            .buffer_unordered(num_workers.clone())
+            .try_collect()
+            .await
+        {
             Ok(res) => res,
             Err(e) => {
                 return Err(e);
             }
         };
-        
+
         let mut results = results;
         results.sort_by_key(|(_, _, index)| *index);
 

--- a/clients/cli/src/runtime.rs
+++ b/clients/cli/src/runtime.rs
@@ -19,12 +19,13 @@ pub async fn start_authenticated_worker(
     environment: Environment,
     client_id: String,
     max_tasks: Option<u32>,
+    num_workers: usize,
 ) -> (
     mpsc::Receiver<Event>,
     Vec<JoinHandle<()>>,
     broadcast::Sender<()>,
 ) {
-    let config = WorkerConfig::new(environment, client_id);
+    let config = WorkerConfig::new(environment, client_id, num_workers);
     let (event_sender, event_receiver) =
         mpsc::channel::<Event>(crate::consts::cli_consts::EVENT_QUEUE_SIZE);
 

--- a/clients/cli/src/session/setup.rs
+++ b/clients/cli/src/session/setup.rs
@@ -114,6 +114,7 @@ pub async fn setup_session(
         env,
         client_id,
         max_tasks,
+        num_workers,
     )
     .await;
 

--- a/clients/cli/src/workers/core.rs
+++ b/clients/cli/src/workers/core.rs
@@ -73,7 +73,11 @@ pub struct WorkerConfig {
 }
 
 impl WorkerConfig {
-    pub fn new(environment: crate::environment::Environment, client_id: String, num_workers: usize) -> Self {
+    pub fn new(
+        environment: crate::environment::Environment,
+        client_id: String,
+        num_workers: usize,
+    ) -> Self {
         Self {
             environment,
             client_id,

--- a/clients/cli/src/workers/core.rs
+++ b/clients/cli/src/workers/core.rs
@@ -69,13 +69,15 @@ impl EventSender {
 pub struct WorkerConfig {
     pub environment: crate::environment::Environment,
     pub client_id: String,
+    pub num_workers: usize,
 }
 
 impl WorkerConfig {
-    pub fn new(environment: crate::environment::Environment, client_id: String) -> Self {
+    pub fn new(environment: crate::environment::Environment, client_id: String, num_workers: usize) -> Self {
         Self {
             environment,
             client_id,
+            num_workers,
         }
     }
 }

--- a/clients/cli/src/workers/prover.rs
+++ b/clients/cli/src/workers/prover.rs
@@ -31,7 +31,7 @@ impl TaskProver {
     /// Generate proof for a task with proper logging
     pub async fn prove_task(&self, task: &Task) -> Result<ProverResult, ProveError> {
         // Use existing prover module for proof generation
-        match authenticated_proving(task, &self.config.environment, &self.config.client_id).await {
+        match authenticated_proving(task, &self.config.environment, &self.config.client_id, &self.config.num_workers).await {
             Ok((proofs, combined_hash, individual_proof_hashes)) => {
                 // Log successful proof generation
                 self.event_sender

--- a/clients/cli/src/workers/prover.rs
+++ b/clients/cli/src/workers/prover.rs
@@ -31,7 +31,14 @@ impl TaskProver {
     /// Generate proof for a task with proper logging
     pub async fn prove_task(&self, task: &Task) -> Result<ProverResult, ProveError> {
         // Use existing prover module for proof generation
-        match authenticated_proving(task, &self.config.environment, &self.config.client_id, &self.config.num_workers).await {
+        match authenticated_proving(
+            task,
+            &self.config.environment,
+            &self.config.client_id,
+            &self.config.num_workers,
+        )
+        .await
+        {
             Ok((proofs, combined_hash, individual_proof_hashes)) => {
                 // Log successful proof generation
                 self.event_sender


### PR DESCRIPTION
fix: #1929

According to the max-threads parameter, multiple processes are started to execute the proof concurrently to speed up the proof.