### PR TITLE
fix: update report proving url

### DIFF
--- a/clients/cli/src/analytics.rs
+++ b/clients/cli/src/analytics.rs
@@ -150,8 +150,7 @@ pub async fn track(
 }
 
 /// Cloud Function endpoint for reporting proving activity
-const REPORT_PROVING_URL: &str =
-    "https://us-central1-nexus-prove.cloudfunctions.net/reportProving";
+const REPORT_PROVING_URL: &str = "https://us-central1-nexus-prove.cloudfunctions.net/reportProving";
 /// User-Agent for nexus-cli requests (used by Cloud Function for special handling)
 const CLI_USER_AGENT: &str = concat!("nexus-cli/", env!("CARGO_PKG_VERSION"));
 

--- a/clients/cli/src/analytics.rs
+++ b/clients/cli/src/analytics.rs
@@ -151,7 +151,7 @@ pub async fn track(
 
 /// Cloud Function endpoint for reporting proving activity
 const REPORT_PROVING_URL: &str =
-    "https://us-central1-nexus-prove-staging.cloudfunctions.net/reportProving";
+    "https://us-central1-nexus-prove.cloudfunctions.net/reportProving";
 /// User-Agent for nexus-cli requests (used by Cloud Function for special handling)
 const CLI_USER_AGENT: &str = concat!("nexus-cli/", env!("CARGO_PKG_VERSION"));
 


### PR DESCRIPTION
Use production rather than staging URL for reporting proving.

Staging and production basically do the same thing so no release is necessary.