### PR TITLE
chore: Minor UX Improvements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ nexus-cli register-node
 nexus-cli start
 ```
 
-To run the CLI in the background, you can also opt to start it in headless mode.
+To run the CLI noninteractively, you can also opt to start it in headless mode.
 
 ```bash
 nexus-cli start --headless

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ nexus-cli register-node
 nexus-cli start
 ```
 
+To run the CLI in the background, you can also opt to start it in headless mode.
+
+```bash
+nexus-cli start --headless
+```
+
 The `register-user` and `register-node` commands will save your credentials to `~/.nexus/config.json`. To clear credentials, run:
 
 ```bash

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -56,7 +56,7 @@ enum Command {
         #[arg(long = "headless", action = ArgAction::SetTrue)]
         headless: bool,
 
-        /// Maximum number of threads to use for proving.
+        /// DEPRECATED: WILL BE IGNORED. Maximum number of threads to use for proving.
         #[arg(long = "max-threads", value_name = "MAX_THREADS")]
         max_threads: Option<u32>,
 


### PR DESCRIPTION
Based on community feedback, this PR makes two (related) UX changes:

- adds a deprecation warning to the `--max-threads` parameter. We'll work on more officially removing/replacing that functionality, but for now we should mark that it is _not expected_  to do anything; and
- documents the `--headless` parameter for background/parallel usage of the CLI.