### PR TITLE
docs: fix typo in comment

### DIFF
--- a/clients/cli/programs/fib_input_initial/src/main.rs
+++ b/clients/cli/programs/fib_input_initial/src/main.rs
@@ -34,7 +34,7 @@ fn main() {
         nexus_sdk::KnownExitCodes::ExitSuccess as u32
     );
 
-    // Normally the prover communicates the seralized proof to the verifier who deserializes it.
+    // Normally the prover communicates the serialized proof to the verifier who deserializes it.
     //
     // The verifier must also possess the program binary and the public i/o. Usually, either
     // the verifier will rebuild the elf in a reproducible way (e.g., within a container) or


### PR DESCRIPTION

- Corrected spelling error in `clients/cli/programs/fib_input_initial/src/main.rs`
- Changed `seralized` to `serialized`

