### PR TITLE
ci: compile architecture overrides

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,8 @@ jobs:
         working-directory: clients/cli
         run: cargo build --release --target x86_64-unknown-linux-gnu
         env:
-          RUSTFLAGS: "-C target-feature=+crt-static"
+          # Override config.toml target-cpu=native with generic for precompiled builds
+          RUSTFLAGS: "-C target-cpu=generic -C target-feature=+crt-static"
 
       # Rename the binary to indicate the target OS
       - name: Rename binary
@@ -150,7 +151,8 @@ jobs:
           export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
           cargo build -Zbuild-std=std,panic_abort --release --target aarch64-unknown-linux-gnu
         env:
-          RUSTFLAGS: "-C target-feature=+crt-static"
+          # Override config.toml target-cpu=native with generic for precompiled builds
+          RUSTFLAGS: "-C target-cpu=generic -C target-feature=+crt-static"
 
       # Rename the binary to indicate the target OS
       - name: Rename binary
@@ -212,7 +214,8 @@ jobs:
         env:
           RUSTUP_TOOLCHAIN: ${{ env.RUSTUP_TOOLCHAIN }}
           RUSTC_BOOTSTRAP: 1
-          RUSTFLAGS: "-C target-feature=+sse4.2,+avx,+avx2"
+          # Override config.toml target-cpu=native with generic for precompiled builds
+          RUSTFLAGS: "-C target-cpu=generic -C target-feature=+sse4.2,+avx,+avx2"
 
       # Rename the binary to indicate the target OS
       - name: Rename binary
@@ -268,7 +271,8 @@ jobs:
         working-directory: clients/cli
         run: cargo build --release --target=aarch64-apple-darwin
         env:
-          RUSTFLAGS: "-C target-feature=+neon,+fp-armv8,+crc"
+          # Override config.toml target-cpu=native with apple-m1 for precompiled builds
+          RUSTFLAGS: "-C target-cpu=apple-m1 -C target-feature=+neon,+fp-armv8,+crc"
 
       # Rename the binary to indicate the target OS and platform
       - name: Rename binary
@@ -320,7 +324,8 @@ jobs:
         working-directory: clients/cli
         run: cargo build --release --target=x86_64-pc-windows-msvc
         env:
-          RUSTFLAGS: "-C target-feature=+sse4.2,+avx,+avx2"
+          # Override config.toml target-cpu=native with generic for precompiled builds
+          RUSTFLAGS: "-C target-cpu=generic -C target-feature=+sse4.2,+avx,+avx2"
 
       # Rename the binary to indicate the target OS and platform
       - name: Rename binary


### PR DESCRIPTION
Choose safer defaults for precompiled builds

## Order of Precedence

Cargo checks for flags in a specific order, with later sources overriding earlier ones: 
- CARGO_ENCODED_RUSTFLAGS environment variable
- RUSTFLAGS environment variable
- target.<target-triple>.rustflags configuration entries
- build.rustflags configuration value